### PR TITLE
Food state fix

### DIFF
--- a/sapai/foods.py
+++ b/sapai/foods.py
@@ -120,7 +120,7 @@ class Food():
         food = cls(name=state["name"])
         food.attack = state["attack"]
         food.health = state["health"]
-        food.eaten = state["eaten"],
+        food.eaten = state["eaten"]
         ### Supply seed_state in state dict should be optional
         if "seed_state" in state:
             if state["seed_state"] != None:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -46,7 +46,6 @@ class TestState(unittest.TestCase):
 
     def test_shop_state_equality(self):
         expected = Shop()
-        expected.roll()
         actual = Shop.from_state(expected.state)
         self.assertEqual(expected.state, actual.state)
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -44,6 +44,12 @@ class TestState(unittest.TestCase):
         compressed = compress(expected, minimal=True)
         actual = decompress(compressed)
 
+    def test_shop_state_equality(self):
+        expected = Shop()
+        expected.roll()
+        actual = Shop.from_state(expected.state)
+        self.assertEqual(expected.state, actual.state)
+
     def test_compress_player(self):
         expected = Player()
         compressed = compress(expected, minimal=True)


### PR DESCRIPTION
The extra comma caused the `eaten` to be a tuple, which causes the states to not be equivalent after recreating the shop from a state.