### PR TITLE
Fix shop rerolling when created from empty shop

### DIFF
--- a/sapai/shop.py
+++ b/sapai/shop.py
@@ -94,7 +94,7 @@ for key,value in data["foods"].items():
 
 class Shop():
     def __init__(self, 
-                 shop_slots=[], 
+                 shop_slots=None,
                  turn=1, 
                  can=0,
                  pack="StandardPack",
@@ -130,7 +130,7 @@ class Shop():
             raise Exception("Pack {} not valid".format(pack))
         
         self.update_shop_rules()
-        if len(shop_slots) > 0:
+        if shop_slots is not None:
             self.shop_slots = [
                 ShopSlot(x,pack=self.pack,turn=self.turn,seed_state=self.seed_state) for x in shop_slots]
             

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -38,3 +38,12 @@ class TestShop(unittest.TestCase):
         expected_end_health = start_health + 1
         self.assertEqual(test_player.team[0].pet.health, expected_end_health)
 
+    def test_empty_shop_from_state(self):
+        pet = Pet("fish")
+        orig_shop = Shop(shop_slots=[pet])
+        orig_shop.buy(pet)
+        self.assertEqual(len(orig_shop.shop_slots), 0)
+
+        copy_shop = Shop.from_state(orig_shop.state)
+        self.assertEqual(len(copy_shop.shop_slots), 0)
+


### PR DESCRIPTION
- When a shop was empty, if it was recreated from state, it would reroll the shop. This PR fixes that
- Regression test