### PR TITLE
Canned food / chicken

### DIFF
--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -594,7 +594,7 @@ def battle_phase_hurt_and_faint(battle_obj,
         for team_idx,pet_idx in pp:
             fteam,oteam = get_teams([team_idx,pet_idx],teams)
             p = fteam[pet_idx].pet
-            if p._hurt > 0:
+            while p._hurt > 0:
                 hurt_list.append([team_idx,pet_idx])
                 activated,targets,possible = p.hurt_trigger(oteam)
                 append_phase_list(phase_list,

--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -6,7 +6,7 @@ from sapai.data import data
 from sapai.pets import Pet
 from sapai.teams import Team
 from sapai.effects import get_effect_function,get_pet,get_teams,\
-                            SummonPet,SummonRandomPet
+                            RespawnPet,SummonPet,SummonRandomPet
 
 
 class Battle():
@@ -61,7 +61,7 @@ class Battle():
         self.battle_history = {}
         
         ### Build initial effect queue order
-        self.update_pet_priority()
+        self.pet_priority = self.update_pet_priority(self.t0, self.t1)
     
     
     def battle(self):
@@ -71,7 +71,7 @@ class Battle():
         battle_iter = 0
         while True:
             ### First update effect order
-            self.update_pet_priority()
+            self.pet_priority = self.update_pet_priority(self.t0, self.t1)
             ### Then attack
             result = self.attack(battle_iter)
             battle_iter += 1
@@ -112,7 +112,7 @@ class Battle():
             
             ### If animals have moved or fainted then effect order must be updated
             if temp_phase.startswith("phase_move"):
-                self.update_pet_priority()
+                self.pet_priority = self.update_pet_priority(t0, t1)
         
     
     def attack(self, battle_iter):
@@ -214,8 +214,8 @@ class Battle():
         ### Must have been draw
         return 2
     
-    
-    def update_pet_priority(self):
+    @staticmethod
+    def update_pet_priority(t0, t1):
         """ 
         
         Prepares the order that the animals effects should be considered in
@@ -226,10 +226,10 @@ class Battle():
         
         """
         ### Build all data types to determine effect order
-        pets = [x for x in self.t0] + [x for x in self.t1]
-        attack = [x.attack for x in self.t0] + [x.attack for x in self.t1]
-        health = [x.health for x in self.t0] + [x.health for x in self.t1]
-        teams = [0 for x in self.t0] + [1 for x in self.t1]
+        pets = [x for x in t0] + [x for x in t1]
+        attack = [x.attack for x in t0] + [x.attack for x in t1]
+        health = [x.health for x in t0] + [x.health for x in t1]
+        teams = [0 for x in t0] + [1 for x in t1]
         idx = [x for x in range(5)] + [x for x in range(5)]
         
         for iter_idx,value in enumerate(attack):
@@ -308,11 +308,13 @@ class Battle():
                 raise Exception("That's impossible. Sorting issue.") 
         
         ### Build final queue
-        self.pet_priority = []
+        pet_priority = []
         for t,i in zip(teams,idx):
-            if [self.t0,self.t1][t][i].empty == True:
+            if [t0,t1][t][i].empty == True:
                 continue
-            self.pet_priority.append((t,i))
+            pet_priority.append((t,i))
+        
+        return pet_priority
             
 
 
@@ -347,7 +349,7 @@ class RBattle(Battle):
         self.battle_list = []
         
         ### Build initial effect queue order
-        self.update_pet_priority()
+        self.pet_priority = self.update_pet_priority(self.t0, self.t1)
         
         raise Exception("Not implemented")
 
@@ -435,7 +437,7 @@ def check_summon_triggers(phase_list,
         return 0
     
     func = get_effect_function(p)
-    if func not in [SummonPet,SummonRandomPet]:
+    if func not in [RespawnPet,SummonPet,SummonRandomPet]:
         return 0
     
     if "team" in p.ability["effect"]:
@@ -487,14 +489,14 @@ def check_self_summoned_triggers(teams,
         append_phase_list(phase_list,p,team_idx,pet_idx,True,target, [target])
 
 
-def check_honey(phase_list,p,team_idx,pet_idx,teams):
-    if p.status != "status-honey-bee":
+def check_status_triggers(phase_list,p,team_idx,pet_idx,teams):
+    if p.status not in ["status-honey-bee", "status-extra-life"]:
         return 
     
-    honey_ability = data["statuses"]["status-honey-bee"]["ability"]
-    p.set_ability(honey_ability)
+    ability = data["statuses"][p.status]["ability"]
+    p.set_ability(ability)
     te_idx = [team_idx,pet_idx]
-    activated,targets,possible = p.faint_trigger(trigger=p, te_idx=te_idx)
+    activated,targets,possible = p.faint_trigger(p, te_idx)
     append_phase_list(phase_list,p,team_idx,pet_idx,activated,targets,possible)
     check_summon_triggers(phase_list,
                             p,
@@ -519,9 +521,7 @@ def battle_phase_start(battle_obj,
         activated,targets,possible = p.sob_trigger(oteam)
         append_phase_list(phase_list,p,team_idx,pet_idx,activated,targets,possible)
     
-    check_self_summoned_triggers(teams,
-                                 pet_priority,
-                                 phase_dict)
+    check_self_summoned_triggers(teams,pet_priority,phase_dict)
     
     return phase_list
 
@@ -530,112 +530,91 @@ def battle_phase_hurt_and_faint(battle_obj,
                                 phase,
                                 teams,
                                 pet_priority,
-                                phase_dict,
-                                recursive=False):
+                                phase_dict):
     phase_list = phase_dict[phase]
     pp = pet_priority
-    for team_idx,pet_idx in pp:
-        p = teams[team_idx][pet_idx].pet
-        fteam,oteam = get_teams([team_idx,pet_idx],teams)
-        if p.name == "pet-none":
-            continue
-        if p.health <= 0:
-            ### Pet has fainted
-            te_idx = [team_idx,pet_idx]
-            
-            ### Activate animals own faint trigger
-            activated,targets,possible = p.faint_trigger(p,te_idx,oteam)
-            append_phase_list(phase_list,
-                              p,
-                              team_idx,
-                              pet_idx,
-                              activated,
-                              targets,
-                              possible)
-            
-            ### If animal was summoned, then need to check for summon triggers
-            nsummoned = check_summon_triggers(phase_list,
-                                  p,
-                                  team_idx,
-                                  pet_idx,
-                                  fteam,
-                                  activated,
-                                  targets,
-                                  possible)
-            
-            ### Check for honey on pet
-            check_honey(phase_list,p,team_idx,pet_idx,teams)
-            
-            ### Then pass to all other animals on friendly team
-            ### Keep track of activations such that they may only be performed
-            ###   once. 
-            activated_dict = {}
-            while True:
-                battle_obj.update_pet_priority()
-                pp = battle_obj.pet_priority
-                activated_bool = False
-                for temp_team_idx,temp_pet_idx in pp:
-                    if temp_team_idx != team_idx:
-                        continue
-                    if pet_idx == temp_pet_idx:
-                        continue
-                    temp_pet = teams[temp_team_idx][temp_pet_idx].pet
-                    if temp_pet in activated_dict:
-                        continue
-                    activated,targets,possible = temp_pet.faint_trigger(
-                                                    trigger=p, te_idx=te_idx)
-                    append_phase_list(phase_list,temp_pet,team_idx,pet_idx,
-                                    activated,targets,possible)
-                    ### If animal was summoned, then need to check for summon triggers
-                    check_summon_triggers(phase_list,
-                                        temp_pet,
-                                        team_idx,
-                                        pet_idx,
-                                        fteam,
-                                        activated,
-                                        targets,
-                                        possible)
-                    if activated:
-                        activated_bool = True
-                        activated_dict[temp_pet] = True
-                if activated_bool == False:
-                    break
-                    
+    status_list = []
+    while True:
+        ### Get a list of fainted pets
+        fainted_list = []
+        for team_idx,pet_idx in pp:
+            p = teams[team_idx][pet_idx].pet
+            if p.name == "pet-none":
+                continue
+            if p.health <= 0:
+                fainted_list.append([team_idx,pet_idx])
+                if p.status != "none":
+                    status_list.append([p,team_idx,pet_idx])
+
+        ### Check every fainted pet
+        faint_targets_list = []
+        for team_idx,pet_idx in fainted_list:
+            fteam,oteam = get_teams([team_idx,pet_idx],teams)
+            fainted_pet = fteam[pet_idx].pet
+            ### Check for all pets that trigger off this fainted pet (including self)
+            for te_team_idx,te_pet_idx in pp:
+                other_pet = teams[te_team_idx][te_pet_idx].pet
+                te_idx = [te_team_idx,te_pet_idx]
+                activated,targets,possible = other_pet.faint_trigger(fainted_pet,te_idx,oteam)
+                if activated:
+                    faint_targets_list.append([fainted_pet,te_team_idx,te_pet_idx,activated,targets,possible])
+                append_phase_list(phase_list,
+                                other_pet,
+                                te_team_idx,
+                                te_pet_idx,
+                                activated,
+                                targets,
+                                possible)
+
             ### If no trigger was activated, then the pet was never removed.
             ###   Check to see if it should be removed now. 
-            if teams[team_idx].check_friend(p):
-                teams[team_idx].remove(p)
+            if teams[team_idx].check_friend(fainted_pet):
+                teams[team_idx].remove(fainted_pet)
                 ### Add this info to phase list
                 phase_list.append((
                     "Fainted",
                     (team_idx,pet_idx),
-                    (p.__repr__()),
+                    (fainted_pet.__repr__()),
                     [""]))
-                
-        elif p._hurt:
-            ### Pet has been hurt. Only need to activate self trigger because 
-            ###   there's presently no Pet that activates from another pet 
-            ###   being hurt.
-            activated,targets,possible = p.hurt_trigger(trigger=oteam)
-            append_phase_list(phase_list,p,team_idx,pet_idx,
-                                  activated,targets,possible)
-            
-        else:
-            pass
-    
-    ### Call faint recursively to handle the case where other animals may 
-    ###   faint due to another fainting, such as a badger
-    if not recursive: 
-        ### If recursive call has already been made, then this part of the 
-        ###   function should not be entered
-        while True:
-            battle_obj.update_pet_priority()
-            pet_priority = battle_obj.pet_priority
-            temp_phase_list = battle_phase_hurt_and_faint(
-                            battle_obj,phase,teams,pet_priority,phase_dict,
-                            recursive=True)
-            if len(temp_phase_list) == len(phase_list):
-                break
+
+        ### If pet was summoned, then need to check for summon triggers
+        for fainted_pet,team_idx,pet_idx,activated,targets,possible in faint_targets_list:
+            fteam,_ = get_teams([team_idx,pet_idx],teams)
+            check_summon_triggers(phase_list,
+                                fainted_pet,
+                                team_idx,
+                                pet_idx,
+                                fteam,
+                                activated,
+                                targets,
+                                possible)
+
+        ### If pet was hurt, then need to check for hurt triggers
+        hurt_list = []
+        for team_idx,pet_idx in pp:
+            fteam,oteam = get_teams([team_idx,pet_idx],teams)
+            p = fteam[pet_idx].pet
+            if p._hurt > 0:
+                hurt_list.append([team_idx,pet_idx])
+                activated,targets,possible = p.hurt_trigger(oteam)
+                append_phase_list(phase_list,
+                                p,
+                                team_idx,
+                                pet_idx,
+                                activated,
+                                targets,
+                                possible)
+
+        battle_obj.pet_priority = battle_obj.update_pet_priority(battle_obj.t0, battle_obj.t1)
+        pp = battle_obj.pet_priority
+
+        ### If nothing happend, stop the loop
+        if len(fainted_list) == 0 and len(hurt_list) == 0:
+            break
+
+    ### Check for status triggers on pet
+    for p,team_idx,pet_idx in status_list:
+        check_status_triggers(phase_list,p,team_idx,pet_idx,teams)
     
     return phase_list
 
@@ -670,18 +649,18 @@ def get_attack_idx(phase,teams,pet_priority,phase_dict):
     These are defined as the first animals in each team that have a health above
     zero. 
     """
-    t0_idx = -1
-    for iter_idx,temp_slot in enumerate(teams[0]):
-        if not temp_slot.empty:
-            if temp_slot.pet.health > 0:
-                t0_idx = iter_idx
-                break
-    t1_idx = -1
-    for iter_idx,temp_slot in enumerate(teams[1]):
-        if not temp_slot.empty:
-            if temp_slot.pet.health > 0:
-                t1_idx = iter_idx
-                break
+    ### Only check for the first target
+    ### Ff there is no target it means the target fainted in the 'before_attack' phase
+    if not teams[0][0].empty and teams[0][0].pet.health > 0:
+        t0_idx = 0
+    else:
+        t0_idx = -1
+
+    if not teams[1][0].empty and teams[1][0].pet.health > 0:
+        t1_idx = 0
+    else:
+        t1_idx = -1
+        
     ret_idx = []
     if t0_idx > -1:
         ret_idx.append((0,t0_idx))

--- a/sapai/data.py
+++ b/sapai/data.py
@@ -9104,7 +9104,7 @@ data = {
           "kind": "ModifyStats",
           "target": {
             "kind": "EachShopAnimal",
-            "includingFuture": False
+            "includingFuture": True
           },
           "attackAmount": 1,
           "healthAmount": 1,
@@ -9121,7 +9121,7 @@ data = {
           "kind": "ModifyStats",
           "target": {
             "kind": "EachShopAnimal",
-            "includingFuture": False
+            "includingFuture": True
           },
           "attackAmount": 2,
           "healthAmount": 2,
@@ -9138,7 +9138,7 @@ data = {
           "kind": "ModifyStats",
           "target": {
             "kind": "EachShopAnimal",
-            "includingFuture": False
+            "includingFuture": True
           },
           "attackAmount": 3,
           "healthAmount": 3,

--- a/sapai/data.py
+++ b/sapai/data.py
@@ -6364,7 +6364,7 @@ data = {
       ],
       "level1Ability": {
         "description": "Pet eats shop food: Give it +1 Health",
-        "trigger": "BuyFood",
+        "trigger": "EatsShopFood",
         "triggeredBy": {
           "kind": "EachFriend"
         },
@@ -6379,7 +6379,7 @@ data = {
       },
       "level2Ability": {
         "description": "Pet eats shop food: Give it +2 Health",
-        "trigger": "BuyFood",
+        "trigger": "EatsShopFood",
         "triggeredBy": {
           "kind": "EachFriend"
         },
@@ -6394,7 +6394,7 @@ data = {
       },
       "level3Ability": {
         "description": "Pet eats shop food: Give it +3 Health",
-        "trigger": "BuyFood",
+        "trigger": "EatsShopFood",
         "triggeredBy": {
           "kind": "EachFriend"
         },

--- a/sapai/effects.py
+++ b/sapai/effects.py
@@ -113,7 +113,9 @@ def get_target(apet,
     
     Arguments
     ---------
-    pet_idx: list
+    apet: Pet or Food
+        Data to use for ability/effect/etc
+    apet_idx: list
         List of two indices that provide the team index and the pet index 
         that has requested to obtain target pets
     teams: list
@@ -126,8 +128,10 @@ def get_target(apet,
     te: Pet
         Triggering entity
     """
-    p = apet
-    effect = p.ability["effect"]
+    if type(apet).__name__ == "Pet":
+        effect = apet.ability["effect"]
+    elif type(apet).__name__ == "Food":
+        effect = apet.effect
     
     if len(teams) == 1:
         teams = [teams[0], []]
@@ -290,7 +294,7 @@ def get_target(apet,
         return ret_pets,[ret_pets]
     
     elif kind == "EachShopAnimal":
-        shop = p.shop
+        shop = apet.shop
         if shop == None:
             return [],[]
         else:

--- a/sapai/effects.py
+++ b/sapai/effects.py
@@ -654,6 +654,9 @@ def ModifyStats(apet,apet_idx,teams,te=None,te_idx=[],fixed_targets=[]):
         else:
             target_pet._attack += attack_amount
             target_pet._health += health_amount
+        if "includingFuture" in apet.ability["effect"]["target"] and apet.ability["effect"]["target"]["includingFuture"] is True:
+            target_pet.shop.shop_attack += attack_amount
+            target_pet.shop.shop_health += health_amount
         target_pet._attack = min([target_pet._attack,50])
         target_pet._health = min([target_pet._health,50])
     

--- a/sapai/effects.py
+++ b/sapai/effects.py
@@ -743,6 +743,59 @@ def RepeatAbility(apet,apet_idx,teams,te=None,te_idx=[],fixed_targets=[]):
     te.level = original_level
     return targets,possible
 
+def RespawnPet(apet,apet_idx,teams,te=None,te_idx=[],fixed_targets=[]):
+    """
+    Only for Mushroom food at the moment
+
+    """
+    if len(te_idx) == 0:
+        raise Exception(
+            "Indices of triggering entity must be provided as te_idx")
+    
+    fteam,_ = get_teams(apet_idx,teams)
+    spet_name = apet.name
+    
+    if len(fixed_targets) > 0:
+        raise Exception("Not implemented")
+    
+    target_team = fteam
+    #### First, determine how many pets should be infront
+    nahead = len(fteam.get_ahead(te_idx[1],n=5))
+    npets = len(fteam)
+    ### Then move team as far backward as possible
+    fteam.move_backward()
+    ### Move nahead pets forward which should be infront of the triggering pet
+    end_idx = (5-npets)+nahead
+    fteam.move_forward(start_idx=0, end_idx=end_idx)
+    
+    target = []
+    ### Check for furthest back open position
+    empty_idx = []
+    for iter_idx,temp_slot in enumerate(target_team):
+        if temp_slot.empty:
+            empty_idx.append(iter_idx)
+    if len(empty_idx) == 0:
+        ### Can safely return, cannot summon
+        return target,[target]
+            
+    target_slot_idx = np.max(empty_idx)
+    target_team[target_slot_idx] = spet_name
+    spet = target_team[target_slot_idx].pet
+    
+    if "baseAttack" in apet.ability["effect"]:
+        spet._attack = apet.ability["effect"]["baseAttack"]
+    if "baseHealth" in apet.ability["effect"]:
+        spet._health = apet.ability["effect"]["baseHealth"]
+    spet.level = apet.level
+    target.append(spet)
+        
+    ### Move back forward
+    target_team.move_forward()
+    for temp_slot in target_team:
+        ### Make sure team is assigned correctly to all pets
+        temp_slot.pet.team = target_team 
+    
+    return target,[target]
 
 def SummonPet(apet,apet_idx,teams,te=None,te_idx=[],fixed_targets=[]):
     """

--- a/sapai/effects.py
+++ b/sapai/effects.py
@@ -655,8 +655,9 @@ def ModifyStats(apet,apet_idx,teams,te=None,te_idx=[],fixed_targets=[]):
             target_pet._attack += attack_amount
             target_pet._health += health_amount
         if "includingFuture" in apet.ability["effect"]["target"] and apet.ability["effect"]["target"]["includingFuture"] is True:
-            target_pet.shop.shop_attack += attack_amount
-            target_pet.shop.shop_health += health_amount
+            if (target_pet.shop is not None):
+                target_pet.shop.shop_attack += attack_amount
+                target_pet.shop.shop_health += health_amount
         target_pet._attack = min([target_pet._attack,50])
         target_pet._health = min([target_pet._health,50])
     

--- a/sapai/foods.py
+++ b/sapai/foods.py
@@ -56,7 +56,7 @@ class Food():
         
         self.attack = 0
         self.health = 0
-        self.effect = fd["effect"]["kind"]
+        self.effect = fd["effect"]
         if "attackAmount" in fd["effect"]:
             self.attack = fd["effect"]["attackAmount"]
             self.base_attack = fd["effect"]["attackAmount"]
@@ -87,10 +87,10 @@ class Food():
             pet._attack += self.attack
             pet._health += self.health
 
-        if self.effect == "ModifyStats":
+        if self.effect["kind"] == "ModifyStats":
             ### Done
             return pet
-        elif self.effect == "ApplyStatus":
+        elif self.effect["kind"] == "ApplyStatus":
             pet.status = self.status
             
     

--- a/sapai/foods.py
+++ b/sapai/foods.py
@@ -67,31 +67,6 @@ class Food():
             self.status = fd["effect"]["status"]
         if "untilEndOfBattle" in fd["effect"] and fd["effect"]["untilEndOfBattle"] is True:
             self.apply_until_end_of_battle = True
-    
-    
-    def apply(self, pet=None):
-        """
-        Serve the food object to the input pet 
-        """
-        if self.eaten == True:
-            raise Exception("This should not be possible")
-        
-        if self.name == "food-canned-food":
-            self.shop.can += self.attack
-            return
-
-        if self.apply_until_end_of_battle:
-            pet._until_end_of_battle_attack_buff += self.attack
-            pet._until_end_of_battle_health_buff += self.health
-        else:
-            pet._attack += self.attack
-            pet._health += self.health
-
-        if self.effect["kind"] == "ModifyStats":
-            ### Done
-            return pet
-        elif self.effect["kind"] == "ApplyStatus":
-            pet.status = self.status
             
     
     def copy(self):

--- a/sapai/pets.py
+++ b/sapai/pets.py
@@ -265,29 +265,49 @@ class Pet():
         return activated,targets,possible
     
     
-    
-    def buy_food_trigger(self, trigger=None):
+    def eats_shop_food_trigger(self, trigger=None):
         """
-        Apply pet's ability when food is bought
-        
-        Pets: 
-            ["beetle", "ladybug", "tabby-cat", "rabbit", "worm", "seal", 
-             "sauropod"]
-        
-        """
+        Apply pet's ability when food is eaten
+
+        Pets:
+            ["beetle", "tabby-cat", "rabbit", "worm", "seal"]
+
+        """        
         activated = False
         targets = []
         possible = []
-        if self.ability["trigger"] not in ["EatsShopFood", "BuyFood"]:
+        if self.ability["trigger"] != "EatsShopFood":
             return activated,targets,possible
         
         if type(trigger).__name__ != "Pet":
             raise Exception("Buy food must input pet that ate as trigger")
         
         ### Check if food has been bought for self is important
-        if self.ability["trigger"] == "EatsShopFood":
+        if self.ability["triggeredBy"]["kind"] == "Self":
             if trigger != self:
                 return activated,targets,possible
+
+        func = get_effect_function(self)
+        pet_idx = self.team.get_idx(self)
+        targets,possible = func(self, [0,pet_idx], [self.team], trigger)
+        
+        activated = True 
+        return activated,targets,possible
+
+
+    def buy_food_trigger(self, trigger=None):
+        """
+        Apply pet's ability when food is bought
+        
+        Pets: 
+            ["ladybug", "sauropod"]
+        
+        """
+        activated = False
+        targets = []
+        possible = []
+        if self.ability["trigger"] != "BuyFood":
+            return activated,targets,possible
 
         func = get_effect_function(self)
         pet_idx = self.team.get_idx(self)

--- a/sapai/pets.py
+++ b/sapai/pets.py
@@ -125,12 +125,17 @@ class Pet():
         else:
             self._attack += food.attack
             self._health += food.health
+
         if food.status != "none":
             self.status = food.status
+
         if food.name == "food-chocolate":
             return self.gain_experience()
         elif food.name == "food-sleeping-pill":
             self._health = -1000
+        elif food.name == "food-canned-food":
+            food.shop.shop_attack += food.attack
+            food.shop.shop_health += food.health
         return False
                 
                 

--- a/sapai/player.py
+++ b/sapai/player.py
@@ -88,6 +88,10 @@ class Player():
             slot._pet.player = self
             slot._pet.shop = self.shop
         
+        for slot in self.shop:
+            slot.item.player = self
+            slot.item.shop = self.shop
+        
         ### This stores the history of actions taken by the given player
         if len(action_history) == 0:
             self.action_history = []

--- a/sapai/player.py
+++ b/sapai/player.py
@@ -252,7 +252,7 @@ class Player():
             hurt_list = []
             for _,pet_idx in pp:
                 p = self.team[pet_idx].pet
-                if p._hurt > 0:
+                while p._hurt > 0:
                     hurt_list.append(pet_idx)
                     activated,targets,possible = p.hurt_trigger(Team())
 

--- a/sapai/shop.py
+++ b/sapai/shop.py
@@ -96,7 +96,8 @@ class Shop():
     def __init__(self, 
                  shop_slots=None,
                  turn=1, 
-                 can=0,
+                 shop_attack=0,
+                 shop_health=0,
                  pack="StandardPack",
                  seed_state=None):
         #### Setting up state
@@ -118,7 +119,8 @@ class Shop():
         self.fslots = 0
         self.pslots = 0
         self.max_slots = 7
-        self.can = can                  ### Keep track of can stats
+        self.shop_attack = shop_attack  ### Keep track of can/chicken stats
+        self.shop_health = shop_health  ### Keep track of can/chicken stats
         
         if pack == "StandardPack":
             self.turn_prob_pets = turn_prob_pets_std
@@ -201,8 +203,8 @@ class Shop():
             ### Add health and attack from previously purchased cans
             if slot.frozen == False:
                 if slot.slot_type == "pet":
-                    slot.item._attack += self.can
-                    slot.item._health += self.can
+                    slot.item._attack += self.shop_attack
+                    slot.item._health += self.shop_health
                 if slot.slot_type == "food":
                     slot.cost = slot.item.cost
         for team_slot in team:
@@ -424,7 +426,8 @@ class Shop():
             "type": "Shop",
             "shop_slots": [x.state for x in self.shop_slots],
             "turn": self.turn,
-            "can": self.can,
+            "shop_attack": self.shop_attack,
+            "shop_health": self.shop_health,
             "pack": self.pack,
             "seed_state": seed_state,
         }
@@ -441,7 +444,8 @@ class Shop():
         return cls(
             shop_slots=[ShopSlot.from_state(x) for x in state["shop_slots"]],
             turn=state["turn"],
-            can=state["can"],
+            shop_attack=state["shop_attack"],
+            shop_health=state["shop_health"],
             pack=state["pack"],
             seed_state=seed_state)
     
@@ -618,7 +622,8 @@ class ShopLearn(Shop):
             "type": "ShopLearn",
             "shop_slots": [x.state for x in self.shop_slots],
             "turn": self.turn,
-            "can": self.can,
+            "shop_attack": self.shop_attack,
+            "shop_health": self.shop_health,
             "pack": self.pack,
             "seed_state": seed_state
         }
@@ -635,7 +640,8 @@ class ShopLearn(Shop):
         return cls(
             shop_slots=[ShopSlot.from_state(x) for x in state["shop_slots"]],
             turn=state["turn"],
-            can=state["can"],
+            shop_attack=state["shop_attack"],
+            shop_health=state["shop_health"],
             pack=state["pack"],
             seed_state=seed_state)
                 

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -1,6 +1,8 @@
 #%%
 import unittest
 
+import numpy as np
+
 from sapai import *
 from sapai.battle import Battle
 from sapai.graph import graph_battle
@@ -36,8 +38,6 @@ class TestBattles(unittest.TestCase):
         t0 = Team(["elephant", "snake", "dragon", "fish"])
         t1 = Team(["cricket", "horse", "fly", "tiger"])
         t0[2]._health = 50
-        print(t0)
-        print(t1)
 
         b = Battle(t0, t1)
         b.battle()
@@ -170,4 +170,212 @@ class TestBattles(unittest.TestCase):
         test_battle = Battle(team1, team2)
         result = test_battle.battle()
         self.assertEqual(result, 0)
+
+    def test_blowfish_pingpong(self):
+        # they hit eachother once, rest of the battle is constant hurt triggers until they both faint
+        b1 = Pet("blowfish")
+        b1._attack = 1
+        b1._health = 50
+        
+        b2 = Pet("blowfish")
+        b2._attack = 1
+        b2._health = 50
+        
+        b = Battle(Team([b1]), Team([b2]))
+        r = b.battle()
+        self.assertTrue("attack 1" not in b.battle_history) # they attack eachother, then keep using hurt_triggers until one of them dies, should never reach a 2nd attack phase
+
+    def test_elephant_blowfish(self):
+        # blowfish snipes first fish in 'before-attack' phase of elephant, leaving elephant without a target to attack normally
+        # then snipes second fish in next turn's 'before attack'
+        state = np.random.RandomState(seed=1).get_state()
+        
+        e1 = Pet("elephant")
+        e1._attack = 1
+        e1._health = 5
+        
+        b1 = Pet("blowfish", seed_state=state)
+        b1._attack = 1
+        b1._health = 5
+        
+        f1 = Pet("fish")
+        f1._attack = 50
+        f1._health = 1
+        f1.status = "status-splash-attack"
+        
+        f2 = Pet("fish")
+        f2._attack = 50
+        f2._health = 1
+        f2.status = "status-splash-attack"
+        
+        b = Battle(Team([e1, b1]), Team([f1, f2]))
+        r = b.battle()
+        self.assertEqual(r, 0)
+    
+    def test_hedgehog_blowfish_camel_hurt_team(self):
+        # standard hedgehog blowfish camel teams facing off against eachother
+        # lots of hurt triggers going off within one turn
+        state1 = np.random.RandomState(seed=2).get_state()
+        state2 = np.random.RandomState(seed=2).get_state()
+
+        bf1 = Pet("blowfish", seed_state=state1)
+        bf1._attack = 20
+        bf1._health = 20
+        bf1.level = 3
+        bf1.status = "status-garlic-armor"
+
+        c1 = Pet("camel")
+        c1._attack = 20
+        c1._health = 20
+        c1.level = 2
+        c1.status = "status-garlic-armor"
+
+        hh1 = Pet("hedgehog")
+        hh2 = Pet("hedgehog")
+
+        bf2 = Pet("blowfish", seed_state=state2)
+        bf2._attack = 20
+        bf2._health = 20
+        bf2.level = 3
+        bf2.status = "status-garlic-armor"
+
+        c2 = Pet("camel")
+        c2._attack = 20
+        c2._health = 20
+        c2.level = 2
+        c2.status = "status-garlic-armor"
+
+        hh3 = Pet("hedgehog")
+        hh4 = Pet("hedgehog")
+
+        b = Battle(Team([hh1, hh2, c1, bf1]), Team([hh3, hh4, c2, bf2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+    
+    def test_hedgehog_vs_honey(self):
+        hh1 = Pet("hedgehog")
+        hh2 = Pet("hedgehog")
+        hh3 = Pet("hedgehog")
+        hh4 = Pet("hedgehog")
+        hh5 = Pet("hedgehog")
+        f1 = Pet("fish")
+        f1.status = "status-honey-bee"
+
+        b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
+        r = b.battle()
+        # ability triggers always go before status triggers
+        # fish wins since honey bee spawns at the end of the turn, after all faint triggers are completed
+        self.assertEqual(r, 1)
+    
+    def test_hedgehog_vs_mushroom(self):
+        hh1 = Pet("hedgehog")
+        hh2 = Pet("hedgehog")
+        hh3 = Pet("hedgehog")
+        hh4 = Pet("hedgehog")
+        hh5 = Pet("hedgehog")
+        f1 = Pet("fish")
+        f1.status = "status-extra-life"
+
+        b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
+        r = b.battle()
+        # ability triggers always go before status triggers
+        # fish wins since mushroom spawns at the end of the turn, after all faint triggers are completed
+        self.assertEqual(r, 1)
+
+    def test_mushroom_scorpion(self):        
+        scorpion = Pet("scorpion")
+        scorpion.status = "status-extra-life"
+        b = Battle(Team([scorpion]), Team(["dragon"]))
+        r = b.battle()
+        self.assertEqual(r, 2) # draw since scorpion respawns with poison.
+    
+    def test_badger_draws(self):
+        # normal 1v1
+        b1 = Pet("badger")
+        b2 = Pet("badger")
+        b = Battle(Team([b1]), Team([b2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # 1 survives, enemy ability kills
+        b1 = Pet("badger")
+        b1._health = 6
+        b2 = Pet("badger")
+        b = Battle(Team([b1]), Team([b2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # normal honey 1v1
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        hb2 = Pet("badger")
+        hb2.status = "status-honey-bee"
+        b = Battle(Team([hb1]), Team([hb2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # 1 survives, enemy ability kills
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        hb1._health = 6
+        hb2 = Pet("badger")
+        hb2.status = "status-honey-bee"
+        b = Battle(Team([hb1]), Team([hb2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # 1 survives, enemey ability kills, even with less attack priority should NOT be able to hit bee with ability
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        hb1._attack = 4
+        hb1._health = 6
+        hb2 = Pet("badger")
+        hb2.status = "status-honey-bee"
+        b = Battle(Team([hb1]), Team([hb2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # badger with less attack can kill zombie-cricket
+        b1 = Pet("badger")
+        c1 = Pet("cricket")
+        c1._attack = 6
+        b = Battle(Team([b1]), Team([c1]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # badger with higher priority hits nothing with ability, zombie-cricket spanws and bee spawns
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        c1 = Pet("cricket")
+        c1._attack = 4
+        b = Battle(Team([hb1]), Team([c1]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+    def test_badger_wins(self):
+        # bee win
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        b2 = Pet("badger")
+        b = Battle(Team([hb1]), Team([b2]))
+        r = b.battle()
+        self.assertEqual(r, 0)
+
+        # badger with higher priority hits nothing with ability, zombie-cricket spanws and wins
+        c1 = Pet("cricket")
+        c1._attack = 4
+        b1 = Pet("badger")
+        b = Battle(Team([c1]), Team([b1]))
+        r = b.battle()
+        self.assertEqual(r, 0)
+
+        # badger with less attack can kill zombie-cricket, then bee spawns
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        c1 = Pet("cricket")
+        c1._attack = 6
+        b = Battle(Team([hb1]), Team([c1]))
+        r = b.battle()
+        self.assertEqual(r, 0)
+
 # %%

--- a/tests/test_pet_triggers.py
+++ b/tests/test_pet_triggers.py
@@ -75,10 +75,32 @@ class TestPetTriggers(unittest.TestCase):
             activated_bool, targets, possible = pet.sell_trigger(pet.team[0].pet)
             self.assertEqual(activated_bool, test_bool_list[iter_idx])
 
+    def test_eats_shop_food_triggers_self(self):
+        test_team = Team([Pet("dragon"), Pet("cat")])
+        test_pet_names = ["beetle", "tabby-cat", "rabbit", "worm", "seal"]
+
+        test_pet_list = [Pet(x, shop=Shop(), team=test_team.copy(), player=Player()) for x in test_pet_names]
+        self.print_pet_list(test_pet_list)
+
+        # Buy food for self
+        for pet in test_pet_list:
+            activated_bool, targets, possible = pet.eats_shop_food_trigger(pet)
+            self.assertTrue(activated_bool)
+
+    def test_eats_shop_food_triggers_other(self):
+        test_team = Team([Pet("dragon"), Pet("cat")])
+        test_pet_names = ["beetle", "tabby-cat", "rabbit", "worm", "seal"]
+        test_pet_list = [Pet(x, shop=Shop(), team=test_team.copy(), player=Player()) for x in test_pet_names]
+
+        # Buy food for other
+        test_bool_list = [False, False, True, False, False]
+        for iter_idx, pet in enumerate(test_pet_list):
+            activated_bool, targets, possible = pet.eats_shop_food_trigger(pet.team[0].pet)
+            self.assertEqual(activated_bool, test_bool_list[iter_idx])
+
     def test_buy_food_triggers_self(self):
         test_team = Team([Pet("dragon"), Pet("cat")])
-        test_pet_names = ["beetle", "ladybug", "tabby-cat", "rabbit", "worm", "seal",
-                          "sauropod"]
+        test_pet_names = ["ladybug", "sauropod"]
 
         test_pet_list = [Pet(x, shop=Shop(), team=test_team.copy(), player=Player()) for x in test_pet_names]
         self.print_pet_list(test_pet_list)
@@ -90,12 +112,11 @@ class TestPetTriggers(unittest.TestCase):
 
     def test_buy_food_triggers_other(self):
         test_team = Team([Pet("dragon"), Pet("cat")])
-        test_pet_names = ["beetle", "ladybug", "tabby-cat", "rabbit", "worm", "seal",
-                          "sauropod"]
+        test_pet_names = ["ladybug", "sauropod"]
         test_pet_list = [Pet(x, shop=Shop(), team=test_team.copy(), player=Player()) for x in test_pet_names]
 
         # Buy food for other
-        test_bool_list = [False, True, False, True, False, False, True]
+        test_bool_list = [True, True]
         for iter_idx, pet in enumerate(test_pet_list):
             activated_bool, targets, possible = pet.buy_food_trigger(pet.team[0].pet)
             self.assertEqual(activated_bool, test_bool_list[iter_idx])

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -132,3 +132,41 @@ class TestShop(unittest.TestCase):
         self.assertEqual(player.team[1].health, 3) # 2 + seal
         self.assertEqual(player.team[2].attack, 3) # 1 + seal + ladybug
         self.assertEqual(player.team[2].health, 5) # 3 + seal + ladybug
+
+    def test_chicken(self):
+        state = np.random.RandomState(seed=1).get_state()
+        player = Player(shop=Shop(["fish", "fish"], seed_state=state), team=["chicken"])
+        player.buy_pet(0)
+        self.assertEqual(player.shop[0].item.attack, 3)
+        self.assertEqual(player.shop[0].item.health, 4)
+
+        ### check result after 1 roll
+        player.roll()
+        self.assertEqual(player.shop[0].item.attack, 3) # beaver 2/2
+        self.assertEqual(player.shop[0].item.health, 3)
+
+        ### check result in a new turn
+        player.end_turn()
+        player.start_turn()
+        self.assertEqual(player.shop[0].item.attack, 2) # duck 1/3
+        self.assertEqual(player.shop[0].item.health, 4)
+
+    def test_canned_food(self):
+        state = np.random.RandomState(seed=1).get_state()
+        player = Player(shop=Shop(["fish", "canned-food"], seed_state=state), team=["fish"])
+        player.buy_food(1)
+
+        ### check immediate result
+        self.assertEqual(player.shop[0].item.attack, 4)
+        self.assertEqual(player.shop[0].item.health, 4)
+
+        ### check result after 1 roll
+        player.roll()
+        self.assertEqual(player.shop[0].item.attack, 4) # beaver 2/2
+        self.assertEqual(player.shop[0].item.health, 3)
+
+        ### check result in a new turn
+        player.end_turn()
+        player.start_turn()
+        self.assertEqual(player.shop[0].item.attack, 3) # duck 1/3
+        self.assertEqual(player.shop[0].item.health, 4)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -97,3 +97,38 @@ class TestShop(unittest.TestCase):
         player = Player(shop=Shop([]), team=Team([pet]))
         pet.sot_trigger()
         self.assertEqual(len(player.shop),1)
+
+    def test_buy_multi_target_food(self):
+        player = Player(shop=["sushi"], team=["seal", "rabbit", "ladybug"])
+        player.buy_food(0)
+        self.assertEqual(player.team[0].attack, 4) # 3 + sushi
+        self.assertEqual(player.team[0].health, 10) # 8 + sushi + rabbit
+        self.assertEqual(player.team[1].attack, 5) # 3 + sushi + seal
+        self.assertEqual(player.team[1].health, 5) # 2 + sushi + seal + rabbit
+        self.assertEqual(player.team[2].attack, 4) # 1 + sushi + seal + ladybug
+        self.assertEqual(player.team[2].health, 7) # 3 + sushi + seal + rabbit + ladybug
+
+    def test_buy_multi_target_food_empty_team(self):
+        player = Player(shop=["sushi"], team=[])
+        player.buy_food(0)
+
+    def test_buy_chocolate(self):
+        player = Player(shop=["chocolate"], team=["seal", "rabbit", "ladybug"])
+        player.buy_food(0, 0)
+        self.assertEqual(player.team[0].pet.experience, 1)
+        self.assertEqual(player.team[0].attack, 3) # 3
+        self.assertEqual(player.team[0].health, 9) # 8 + rabbit
+        self.assertEqual(player.team[1].attack, 4) # 3 + seal
+        self.assertEqual(player.team[1].health, 3) # 2 + seal
+        self.assertEqual(player.team[2].attack, 3) # 1 + seal + ladybug
+        self.assertEqual(player.team[2].health, 5) # 3 + seal + ladybug
+
+    def test_buy_apple(self):
+        player = Player(shop=["apple"], team=["seal", "rabbit", "ladybug"])
+        player.buy_food(0, 0)
+        self.assertEqual(player.team[0].attack, 4) # 3 + apple
+        self.assertEqual(player.team[0].health, 10) # 8 + apple + rabbit
+        self.assertEqual(player.team[1].attack, 4) # 3 + seal
+        self.assertEqual(player.team[1].health, 3) # 2 + seal
+        self.assertEqual(player.team[2].attack, 3) # 1 + seal + ladybug
+        self.assertEqual(player.team[2].health, 5) # 3 + seal + ladybug


### PR DESCRIPTION
I split the can field into a separate attack and health field.
ShopSlots had no reference to player or shop, this is needed for target of canned food for instance
Chicken was on includingFuture: False for some reason
Foods had a completely unused and not maintained apply() function, while pets has the eat() that does the same but is maintained. Added includingFuture/canned-food to the eat() and removed apply() to make it less confusing.
ModifyStats effect now has an includingFuture check

fixed #19 

ps. hopefully this now shows up correctly as a separate pull request