### PR TITLE
Workflow CI + Binary wheel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,13 +1,13 @@
 name: build
 
-on: 
-  push: 
+on:
+  push:
     branches:
       - "*"
-  pull_request: 
-    branches: 
+  pull_request:
+    branches:
       - "*"
-  workflow_dispatch: 
+  workflow_dispatch:
 
 jobs:
   build:
@@ -38,7 +38,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3]
+        python-version: [3.6]
         os: [ubuntu-18.04, windows-2019, macos-11]
 
     steps:
@@ -58,4 +58,3 @@ jobs:
 
     - name: Test library accessibility
       run: python -c "import sapai"
-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,61 @@
+name: build
+
+on: 
+  push: 
+    branches:
+      - "*"
+  pull_request: 
+    branches: 
+      - "*"
+  workflow_dispatch: 
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Install dependencies
+      run: pip install wheel setuptools
+
+    - name: Build wheel
+      run: python setup.py bdist_wheel
+
+    - name: Upload Python wheel
+      uses: actions/upload-artifact@v2
+      with:
+        name: Python wheel
+        path: ${{github.workspace}}/dist/sapai-*.whl
+        if-no-files-found: error
+
+  test:
+    needs: build
+    runs-on: ${{matrix.os}}
+    strategy:
+      max-parallel: 10
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, 3]
+        os: [ubuntu-18.04, windows-2019, macos-11]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{matrix.python-version}}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{matrix.python-version}}
+
+    - name: Download artifact
+      uses: actions/download-artifact@master
+      with:
+        name: "Python wheel"
+
+    - name: Install wheel
+      run: pip install --find-links=${{github.workspace}} sapai
+
+    - name: Test library accessibility
+      run: python -c "import sapai"
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 
 setup(
       name='sapai',
-      version='0.0',
+      version='0.1.0',
       packages=['sapai',
                 ],
       #find_packages(exclude=[]),


### PR DESCRIPTION
In general, it is a good idea to create binary wheels for python packages, as it simplifies installation. It is also convenient if the goal is to upload the package to PyPI or similar.

I have therefore made a CI workflow that builds the wheel, and added tests to verify that it can be installed and imported on different operating systems and using different python versions 3.6-3.10. The CI is ran for all branches and PRs. We could also run the unit tests in tests/, if of interest. I can add that in the next PR.

I also bumped the release version to `v0.1.0`, as I believe sapai is at a beta development stage.
It would be great if you could release the binary as a Release v0.1.0, if merged.