### PR TITLE
Add tests for Dolphin, crab and butterfly

### DIFF
--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -611,14 +611,19 @@ def run_looping_effect_queue(
                 status_summon = False
                 p, team_idx, pet_idx, trigger_method, effect_args = effect_queue.pop(0)
                 fteam, oteam = get_teams([team_idx, pet_idx], teams)
-                returned = trigger_method(*effect_args)
-                if len(returned) == 3:
-                    activated, targets, possible = returned
+                if (p.health > 0 
+                    or ("faint" in trigger_method.__name__.lower()) 
+                        or ("status" in trigger_method.__name__.lower())):
+                    returned = trigger_method(*effect_args)
+                    if len(returned) == 3:
+                        activated, targets, possible = returned
+                    else:
+                        activated, targets, possible, status_summon = returned
+                    append_phase_list(
+                        phase_list, p, team_idx, pet_idx, activated, targets, possible
+                    )
                 else:
-                    activated, targets, possible, status_summon = returned
-                append_phase_list(
-                    phase_list, p, team_idx, pet_idx, activated, targets, possible
-                )
+                    targets = []
 
                 ### Store any pet that scored a knockout with its effect
                 for temp_target in targets:
@@ -656,9 +661,10 @@ def run_looping_effect_queue(
                                 change_te_idx = entry[-1][1]
                                 change_te_idx[1] = targets[0]
                 elif effect_fn in [Evolve]:
-                    summoned_list += targets
+                    alive_targets = [ t for t in targets if t.health > 0]
+                    summoned_list += alive_targets
                     ### Find correct place in queue for summon effect
-                    for evolve_summoned in targets:
+                    for evolve_summoned in alive_targets:
                         ### TODO: make this into function outside
                         insert_idx = 0
                         for p, _, _, _, _ in effect_queue:

--- a/sapai/effects.py
+++ b/sapai/effects.py
@@ -466,7 +466,11 @@ def get_target(
     elif kind == "HighestHealthFriend":
         health_list = []
         for temp_idx in fidx:
-            health_list.append(fteam[temp_idx].pet.health)
+            # All pets that aren't this pet
+            if fteam[temp_idx].pet is not apet:
+                health_list.append(fteam[temp_idx].pet.health)
+            else:
+                health_list.append(1)
         if len(health_list) == 0:
             return [], []
         max_health = np.max(health_list)
@@ -1067,14 +1071,15 @@ def TransferStats(apet, apet_idx, teams, te=None, te_idx=[], fixed_targets=[]):
             if copy_health:
                 raise Exception("This should not be possible")
         else:
-            temp_from = get_target(apet, apet_idx, teams, te=te, get_from=True)
+            copy_from = get_target(apet, apet_idx, teams, te=te, get_from=True)
+            copy_from = copy_from[0][0]
             ### Randomness not needed as outcome will be the same for all pets
             ###   that have this ability
-            temp_from = temp_from[0][0]
-            if copy_attack:
-                apet._attack = int(temp_from.attack * percentage)
-            if copy_health:
-                apet._health = int(temp_from.health * percentage)
+            if copy_from is not apet:
+                if copy_attack:
+                    apet._attack = max(int(copy_from.attack * percentage), 1)
+                if copy_health:
+                    apet._health = max(int(copy_from.health * percentage), 1)
 
     return target, possible
 

--- a/sapai/effects.py
+++ b/sapai/effects.py
@@ -592,6 +592,9 @@ def GainGold(apet, apet_idx, teams, te=None, te_idx=[], fixed_targets=[]):
 
 
 def Evolve(apet, apet_idx, teams, te=None, te_idx=[], fixed_targets=[]):
+    # If pet is dead, do not evolve
+    if apet.health <= 0:
+        return [], []
     if len(fixed_targets) == 0:
         target, possible = get_target(apet, apet_idx, teams, te=te)
     else:

--- a/tests/test_effect_queue.py
+++ b/tests/test_effect_queue.py
@@ -8,6 +8,7 @@ from sapai import *
 from sapai.battle import Battle, run_looping_effect_queue, battle_phase
 from sapai.graph import graph_battle
 from sapai.compress import *
+from sapai.data import data
 
 ### Remember: Can always graph result with graph_battle(b,verbose=True) to
 ###   visualize behavior of the run_looping_effect_queue
@@ -512,7 +513,41 @@ class TestEffectQueue(unittest.TestCase):
         Test that if crab's attack is smaller than dolphin, it should faint,
         otherwise it should live
         """
-        pass
+        # Test crab with no friends to copy
+        ref_team = Team(["crab"], battle=True)
+        ref_team[0].obj._health = 3
+        t0 = Team(["crab"])
+        t0[0].obj._health = 3
+        t1 = Team(["sloth"])
+        b = run_sob(t0, t1)
+        self.assertEqual(b.t0.state, ref_team.state)
+
+        # Test crab with 3 attack dies to dolphin with 4
+        ref_team = Team(["sloth"], battle=True)
+        ref_team[0].obj._health = 50
+        t0 = Team(["sloth", "crab"])
+        t0[0].obj._health = 50
+        t0[1].obj._attack = 3
+        t1 = Team(["dolphin"])
+        t1[0].obj._attack = 4
+        b = run_sob(t0, t1)
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = run_sob(t1, t0)
+        self.assertEqual(b.t1.state, ref_team.state)
+
+        # Test crab with 3 attack lives to dolphin with 2
+        ref_team = Team(["sloth", "crab"], battle=True)
+        ref_team[0].obj._health = 50
+        ref_team[1].obj._health = 25 - data["pets"]["pet-dolphin"]["level1Ability"]["effect"]["amount"]
+        t0 = Team(["sloth", "crab"])
+        t0[0].obj._health = 50
+        t0[1].obj._attack = 3
+        t1 = Team(["dolphin"])
+        t1[0].obj._attack = 2
+        b = run_sob(t0, t1)
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = run_sob(t1, t0)
+        self.assertEqual(b.t1.state, ref_team.state)
 
     def test_scorpion(self):
         """

--- a/tests/test_effect_queue.py
+++ b/tests/test_effect_queue.py
@@ -290,7 +290,30 @@ class TestEffectQueue(unittest.TestCase):
         b = run_sob(t1, t0)
         self.assertEqual(b.t1.state, ref_team.state)
 
-        ### Check that dolphin will kill butterfly when it's lowest health
+        ### Check that dolphin will kill butterfly when it is:
+        ### lowest health and attack LOWER than dolphin (evolves after dolphin shoots)
+        ref_team = Team(["zombie-fly", "fish", "fly"], battle=True)
+        ref_team[0].obj._attack = 4
+        ref_team[0].obj._health = 4
+        ref_team[1].obj._attack = 50
+        ref_team[1].obj._health = 50
+        ref_team[2].obj.ability_counter = 1
+
+        t0 = Team(["caterpillar", "fish", "fly"])
+        t0[0].obj._attack = 1
+        t0[0].obj._health = 1
+        t0[0].obj.level = 3
+        t0[1].obj._attack = 50
+        t0[1].obj._health = 50
+        t1 = Team(["dolphin"])
+        t1[0].obj._attack = 50
+        b = run_sob(t0, t1)
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = run_sob(t1, t0)
+        self.assertEqual(b.t1.state, ref_team.state)
+
+        ### Check that dolphin will kill caterpillar when it is:
+        ### ANY health and attack HIGHER than dolphin (evolves into 1-1 before dolphin shoots)
         ref_team = Team(["zombie-fly", "fish", "fly"], battle=True)
         ref_team[0].obj._attack = 4
         ref_team[0].obj._health = 4
@@ -300,11 +323,19 @@ class TestEffectQueue(unittest.TestCase):
 
         t0 = Team(["caterpillar", "fish", "fly"])
         t0[0].obj._attack = 50
-        t0[0].obj._health = 1
         t0[0].obj.level = 3
         t0[1].obj._attack = 50
         t0[1].obj._health = 50
         t1 = Team(["dolphin"])
+        t1[0].obj._attack = 1
+        # caterpillar has lowest health (1)
+        t0[0].obj._health = 1
+        b = run_sob(t0, t1)
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = run_sob(t1, t0)
+        self.assertEqual(b.t1.state, ref_team.state)
+        # caterpillar has high health (50) (killed after evolve into butterfly)
+        t0[0].obj._health = 50
         b = run_sob(t0, t1)
         self.assertEqual(b.t0.state, ref_team.state)
         b = run_sob(t1, t0)


### PR DESCRIPTION
- Fixes #86 crab no longer can copy from itself, and always has minimum 1 health
- Add tests for dolphin successfully killing caterpillar before evolve, and after evolve but before butterfly gains stats
- Fix abilities triggering after death when they shouldn't
- Pass newly added tests

Let me know if you'd like anything changed, my first time looking at the codebase so I'm not too familiar with all the inner workings.

A few tests outside of test_effect_queue.py are failing, however I've left them as is as they were also failing previously.