### PR TITLE
Pet Priority

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -48,9 +48,9 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-dev = ["tox (>=3)", "flake8", "pep8-naming", "wheel", "twine"]
+dev = ["flake8", "pep8-naming", "tox (>=3)", "twine", "wheel"]
 docs = ["sphinx (>=5)", "sphinx-autodoc-typehints", "sphinx-rtd-theme"]
-test = ["pytest (>=7)", "pytest-mock (>=3)", "mock (>=4)", "pytest-cov", "coverage"]
+test = ["coverage", "mock (>=4)", "pytest (>=7)", "pytest-cov", "pytest-mock (>=3)"]
 
 [[package]]
 name = "keras"
@@ -93,8 +93,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "tomli"
@@ -129,21 +129,115 @@ python-versions = "^3.9"
 content-hash = "70347df683ab11d61a4905926ef7d40401978ef8223a38ccabccc158c6fcc160"
 
 [metadata.files]
-black = []
-click = []
-colorama = []
-graphviz = []
-keras = []
+black = [
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
+    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
+    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
+    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
+    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
+    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
+    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
+    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
+    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
+    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
+    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
+    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
+    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
+    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
+    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
+    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
+    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
+    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+graphviz = [
+    {file = "graphviz-0.20.1-py3-none-any.whl", hash = "sha256:587c58a223b51611c0cf461132da386edd896a029524ca61a1462b880bf97977"},
+    {file = "graphviz-0.20.1.zip", hash = "sha256:8c58f14adaa3b947daf26c19bc1e98c4e0702cdc31cf99153e6f06904d492bf8"},
+]
+keras = [
+    {file = "keras-2.10.0-py2.py3-none-any.whl", hash = "sha256:26a6e2c2522e7468ddea22710a99b3290493768fc08a39e75d1173a0e3452fdf"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
-numpy = []
-pathspec = []
-platformdirs = []
+numpy = [
+    {file = "numpy-1.23.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c9f707b5bb73bf277d812ded9896f9512a43edff72712f31667d0a8c2f8e71ee"},
+    {file = "numpy-1.23.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ffcf105ecdd9396e05a8e58e81faaaf34d3f9875f137c7372450baa5d77c9a54"},
+    {file = "numpy-1.23.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ea3f98a0ffce3f8f57675eb9119f3f4edb81888b6874bc1953f91e0b1d4f440"},
+    {file = "numpy-1.23.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:004f0efcb2fe1c0bd6ae1fcfc69cc8b6bf2407e0f18be308612007a0762b4089"},
+    {file = "numpy-1.23.3-cp310-cp310-win32.whl", hash = "sha256:98dcbc02e39b1658dc4b4508442a560fe3ca5ca0d989f0df062534e5ca3a5c1a"},
+    {file = "numpy-1.23.3-cp310-cp310-win_amd64.whl", hash = "sha256:39a664e3d26ea854211867d20ebcc8023257c1800ae89773cbba9f9e97bae036"},
+    {file = "numpy-1.23.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1f27b5322ac4067e67c8f9378b41c746d8feac8bdd0e0ffede5324667b8a075c"},
+    {file = "numpy-1.23.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ad3ec9a748a8943e6eb4358201f7e1c12ede35f510b1a2221b70af4bb64295c"},
+    {file = "numpy-1.23.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bdc9febce3e68b697d931941b263c59e0c74e8f18861f4064c1f712562903411"},
+    {file = "numpy-1.23.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:301c00cf5e60e08e04d842fc47df641d4a181e651c7135c50dc2762ffe293dbd"},
+    {file = "numpy-1.23.3-cp311-cp311-win32.whl", hash = "sha256:7cd1328e5bdf0dee621912f5833648e2daca72e3839ec1d6695e91089625f0b4"},
+    {file = "numpy-1.23.3-cp311-cp311-win_amd64.whl", hash = "sha256:8355fc10fd33a5a70981a5b8a0de51d10af3688d7a9e4a34fcc8fa0d7467bb7f"},
+    {file = "numpy-1.23.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bc6e8da415f359b578b00bcfb1d08411c96e9a97f9e6c7adada554a0812a6cc6"},
+    {file = "numpy-1.23.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:22d43376ee0acd547f3149b9ec12eec2f0ca4a6ab2f61753c5b29bb3e795ac4d"},
+    {file = "numpy-1.23.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a64403f634e5ffdcd85e0b12c08f04b3080d3e840aef118721021f9b48fc1460"},
+    {file = "numpy-1.23.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efd9d3abe5774404becdb0748178b48a218f1d8c44e0375475732211ea47c67e"},
+    {file = "numpy-1.23.3-cp38-cp38-win32.whl", hash = "sha256:f8c02ec3c4c4fcb718fdf89a6c6f709b14949408e8cf2a2be5bfa9c49548fd85"},
+    {file = "numpy-1.23.3-cp38-cp38-win_amd64.whl", hash = "sha256:e868b0389c5ccfc092031a861d4e158ea164d8b7fdbb10e3b5689b4fc6498df6"},
+    {file = "numpy-1.23.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:09f6b7bdffe57fc61d869a22f506049825d707b288039d30f26a0d0d8ea05164"},
+    {file = "numpy-1.23.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8c79d7cf86d049d0c5089231a5bcd31edb03555bd93d81a16870aa98c6cfb79d"},
+    {file = "numpy-1.23.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5d5420053bbb3dd64c30e58f9363d7a9c27444c3648e61460c1237f9ec3fa14"},
+    {file = "numpy-1.23.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5422d6a1ea9b15577a9432e26608c73a78faf0b9039437b075cf322c92e98e7"},
+    {file = "numpy-1.23.3-cp39-cp39-win32.whl", hash = "sha256:c1ba66c48b19cc9c2975c0d354f24058888cdc674bebadceb3cdc9ec403fb5d1"},
+    {file = "numpy-1.23.3-cp39-cp39-win_amd64.whl", hash = "sha256:78a63d2df1d947bd9d1b11d35564c2f9e4b57898aae4626638056ec1a231c40c"},
+    {file = "numpy-1.23.3-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:17c0e467ade9bda685d5ac7f5fa729d8d3e76b23195471adae2d6a6941bd2c18"},
+    {file = "numpy-1.23.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91b8d6768a75247026e951dce3b2aac79dc7e78622fc148329135ba189813584"},
+    {file = "numpy-1.23.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:94c15ca4e52671a59219146ff584488907b1f9b3fc232622b47e2cf832e94fb8"},
+    {file = "numpy-1.23.3.tar.gz", hash = "sha256:51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd"},
+]
+pathspec = [
+    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
+    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-torch = []
-typing-extensions = []
+torch = [
+    {file = "torch-1.12.1-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:9c038662db894a23e49e385df13d47b2a777ffd56d9bcd5b832593fab0a7e286"},
+    {file = "torch-1.12.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4e1b9c14cf13fd2ab8d769529050629a0e68a6fc5cb8e84b4a3cc1dd8c4fe541"},
+    {file = "torch-1.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:e9c8f4a311ac29fc7e8e955cfb7733deb5dbe1bdaabf5d4af2765695824b7e0d"},
+    {file = "torch-1.12.1-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:976c3f997cea38ee91a0dd3c3a42322785414748d1761ef926b789dfa97c6134"},
+    {file = "torch-1.12.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:68104e4715a55c4bb29a85c6a8d57d820e0757da363be1ba680fa8cc5be17b52"},
+    {file = "torch-1.12.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:743784ccea0dc8f2a3fe6a536bec8c4763bd82c1352f314937cb4008d4805de1"},
+    {file = "torch-1.12.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b5dbcca369800ce99ba7ae6dee3466607a66958afca3b740690d88168752abcf"},
+    {file = "torch-1.12.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f3b52a634e62821e747e872084ab32fbcb01b7fa7dbb7471b6218279f02a178a"},
+    {file = "torch-1.12.1-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:8a34a2fbbaa07c921e1b203f59d3d6e00ed379f2b384445773bd14e328a5b6c8"},
+    {file = "torch-1.12.1-cp37-none-macosx_11_0_arm64.whl", hash = "sha256:42f639501928caabb9d1d55ddd17f07cd694de146686c24489ab8c615c2871f2"},
+    {file = "torch-1.12.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0b44601ec56f7dd44ad8afc00846051162ef9c26a8579dda0a02194327f2d55e"},
+    {file = "torch-1.12.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:cd26d8c5640c3a28c526d41ccdca14cf1cbca0d0f2e14e8263a7ac17194ab1d2"},
+    {file = "torch-1.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:42e115dab26f60c29e298559dbec88444175528b729ae994ec4c65d56fe267dd"},
+    {file = "torch-1.12.1-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:a8320ba9ad87e80ca5a6a016e46ada4d1ba0c54626e135d99b2129a4541c509d"},
+    {file = "torch-1.12.1-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:03e31c37711db2cd201e02de5826de875529e45a55631d317aadce2f1ed45aa8"},
+    {file = "torch-1.12.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:9b356aea223772cd754edb4d9ecf2a025909b8615a7668ac7d5130f86e7ec421"},
+    {file = "torch-1.12.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6cf6f54b43c0c30335428195589bd00e764a6d27f3b9ba637aaa8c11aaf93073"},
+    {file = "torch-1.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:f00c721f489089dc6364a01fd84906348fe02243d0af737f944fddb36003400d"},
+    {file = "torch-1.12.1-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:bfec2843daa654f04fda23ba823af03e7b6f7650a873cdb726752d0e3718dada"},
+    {file = "torch-1.12.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:69fe2cae7c39ccadd65a123793d30e0db881f1c1927945519c5c17323131437e"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]

--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -53,7 +53,7 @@ class Battle:
 
     """
 
-    def __init__(self, t0, t1, seed: int = None):
+    def __init__(self, t0: Team, t1: Team, seed: int = None):
         """
         Performs the battle between the input teams t1 and t2.
 
@@ -144,7 +144,7 @@ class Battle:
         t0 = self.t0
         t1 = self.t1
 
-        attack_str = "attack {}".format(self.battle_iter)
+        attack_str = f"attack {self.battle_iter}"
         phase_dict = {
             attack_str: {
                 "phase_move_start": [],
@@ -180,18 +180,18 @@ class Battle:
             return False
 
     def check_battle_result(self):
-        f0 = len(self.t0.filled) == 0
-        f1 = len(self.t1.filled) == 0
-        if not f0 and not f1:
+        t0_empty = len(self.t0.filled) == 0
+        t1_empty = len(self.t1.filled) == 0
+        if not t0_empty and not t1_empty:
             ### Fight not over
             return -1
-        elif f0 and f1:
+        elif t0_empty and t1_empty:
             ### Draw
             return 2
-        elif f0:
+        elif t0_empty:
             ### t0 won
             return 0
-        elif f1:
+        elif t1_empty:
             ### t1 won
             return 1
         else:
@@ -215,7 +215,6 @@ class Battle:
         attack = {i: pets[i].attack for i in index}
 
         # Randomised starting order, randomises sorted order of attack ties
-        print()
         index = default_rng(seed).permutation(index)
         # Sort index by attack
         index = sorted(index, reverse=True, key=lambda idx: attack[idx])
@@ -300,7 +299,7 @@ def battle_phase(battle_obj, phase, teams, pet_priority, phase_dict):
         battle_phase_attack(battle_obj, phase, teams, pet_priority, phase_dict)
 
     else:
-        raise Exception("Phase {} not found".format(phase))
+        raise Exception(f"Phase {phase} not found")
 
 
 def battle_phase_attack(battle_obj, phase, teams, pet_priority, phase_dict):
@@ -867,7 +866,7 @@ def append_phase_list(phase_list, p, team_idx, pet_idx, activated, targets, poss
     if activated:
         tiger = False
         if len(targets) > 0:
-            if type(targets[0]) == list:
+            if isinstance(list, targets[0]):
                 tiger = True
         func = get_effect_function(p)
 

--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -196,7 +196,7 @@ class Battle:
 
     def calculate_pet_priority(self):
         """
-        Prepares the order that the animals effects should be considered in
+        Calculates the order that the animals effects should be considered in
 
         Note that effects are performed in the order of highest attack to lowest
         attack. If there is a tie, then health values are compared. If there is

--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -70,7 +70,7 @@ class Battle:
         self.battle_iter = 0
 
         ### Build initial effect queue order
-        self.pet_priority = self.update_pet_priority(self.t0, self.t1)
+        self.pet_priority = self.calculate_pet_priority()
 
     def battle(self):
         ### Perform all effects that occur at the start of the battle
@@ -112,7 +112,7 @@ class Battle:
 
             ### If animals have moved or fainted then effect order must be updated
             if temp_phase.startswith("phase_move"):
-                self.pet_priority = self.update_pet_priority(t0, t1)
+                self.pet_priority = self.calculate_pet_priority()
 
     def attack(self):
         """
@@ -131,7 +131,7 @@ class Battle:
 
         """
         ### First update effect order
-        self.pet_priority = self.update_pet_priority(self.t0, self.t1)
+        self.pet_priority = self.calculate_pet_priority()
         ### Set all pet's hurt values back to 0
         for slot in self.t0:
             slot.pet.reset_hurt()
@@ -194,22 +194,19 @@ class Battle:
         else:
             raise Exception("Impossible")
 
-    @staticmethod
-    def update_pet_priority(t0, t1):
+    def calculate_pet_priority(self):
         """
-
         Prepares the order that the animals effects should be considered in
 
         Note that effects are performed in the order of highest attack to lowest
         attack. If there is a tie, then health values are compared. If there is
         a tie then a random animal is chosen first.
-
         """
         ### Build all data types to determine effect order
-        pets = [x for x in t0] + [x for x in t1]
-        attack = [x.attack for x in t0] + [x.attack for x in t1]
-        health = [x.health for x in t0] + [x.health for x in t1]
-        teams = [0 for x in t0] + [1 for x in t1]
+        pets = [x for x in self.t0] + [x for x in self.t1]
+        attack = [x.attack for x in self.t0] + [x.attack for x in self.t1]
+        health = [x.health for x in self.t0] + [x.health for x in self.t1]
+        teams = [0 for x in self.t0] + [1 for x in self.t1]
         idx = [x for x in range(5)] + [x for x in range(5)]
 
         for iter_idx, value in enumerate(attack):
@@ -287,7 +284,7 @@ class Battle:
         pet_priority = []
         pet_priority_pets = []
         for t, i in zip(teams, idx):
-            if [t0, t1][t][i].empty == True:
+            if [self.t0, self.t1][t][i].empty == True:
                 continue
             pet_priority.append((t, i))
 
@@ -326,7 +323,7 @@ class RBattle(Battle):
         self.battle_list = []
 
         ### Build initial effect queue order
-        self.pet_priority = self.update_pet_priority(self.t0, self.t1)
+        self.pet_priority = self.calculate_pet_priority()
 
         raise Exception("Not implemented")
 
@@ -593,7 +590,7 @@ def run_looping_effect_queue(
             ### Question: Does pet_priority need to be re-evaluated in this loop?
             ###   Should match what actual game does.
             ### For now, putting it in here
-            pp = battle_obj.update_pet_priority(teams[0], teams[1])
+            pp = battle_obj.calculate_pet_priority()
             knockout_queue = []
             summoned_list = []
             faint_list = []
@@ -750,7 +747,7 @@ def run_looping_effect_queue(
 
             ### Then check for additional triggers to add to the queue by the
             ###   pet priority
-            pp = battle_obj.update_pet_priority(teams[0], teams[1])
+            pp = battle_obj.calculate_pet_priority()
 
             before_faint_trigger_list = []
             hurt_trigger_list = []

--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -1,5 +1,6 @@
 import copy
 import numpy as np
+from numpy.random import Generator, default_rng
 
 from sapai.data import data
 from sapai.pets import Pet
@@ -52,10 +53,12 @@ class Battle:
 
     """
 
-    def __init__(self, t0, t1):
+    def __init__(self, t0, t1, seed: int = None):
         """
         Performs the battle between the input teams t1 and t2.
 
+        Args:
+            seed (int, optional): Random seed to use. Defaults to None.
         """
         ### Make copy each team to cary out the battle so that the original
         ### pets are not modified in any way after the battle
@@ -70,7 +73,7 @@ class Battle:
         self.battle_iter = 0
 
         ### Build initial effect queue order
-        self.pet_priority = self.calculate_pet_priority()
+        self.pet_priority = self.calculate_pet_priority(seed)
 
     def battle(self):
         ### Perform all effects that occur at the start of the battle
@@ -194,101 +197,30 @@ class Battle:
         else:
             raise Exception("Impossible")
 
-    def calculate_pet_priority(self):
-        """
-        Calculates the order that the animals effects should be considered in
+    def calculate_pet_priority(self, seed: int = None):
+        """Calculates the order of pet effects.
 
         Note that effects are performed in the order of highest attack to lowest
-        attack. If there is a tie, then health values are compared. If there is
-        a tie then a random animal is chosen first.
+        attack. If there is a tie then a random animal is chosen first.
+
+        Args:
+            seed (int, optional): Random seed to use. Defaults to None.
+
+        Returns:
+            list: List of tuples containing (team_index, pet_index) of
+                non-empty pet slots.
         """
-        ### Build all data types to determine effect order
-        pets = [x for x in self.t0] + [x for x in self.t1]
-        attack = [x.attack for x in self.t0] + [x.attack for x in self.t1]
-        health = [x.health for x in self.t0] + [x.health for x in self.t1]
-        teams = [0 for x in self.t0] + [1 for x in self.t1]
-        idx = [x for x in range(5)] + [x for x in range(5)]
+        pets = [p.pet for p in self.t0] + [p.pet for p in self.t1]
+        index = [i for i in range(10) if isinstance(pets[i].attack, int)]
+        attack = {i: pets[i].attack for i in index}
 
-        for iter_idx, value in enumerate(attack):
-            if value == "none":
-                attack[iter_idx] = 0
-                health[iter_idx] = 0
+        # Randomised starting order, randomises sorted order of attack ties
+        print()
+        index = default_rng(seed).permutation(index)
+        # Sort index by attack
+        index = sorted(index, reverse=True, key=lambda idx: attack[idx])
 
-        ### Basic sorting by max attack
-        sort_idx = np.arange(0, len(attack))
-        attack = np.array(attack)
-        health = np.array(attack)
-        teams = np.array(teams)
-        idx = np.array(idx)
-
-        ### Find attack collisions
-        uniquea = np.unique(attack)[::-1]
-        start_idx = 0
-        for uattack in uniquea:
-            ### Get collision idx
-            temp_idx = np.where(attack == uattack)[0]
-            temp_attack = attack[temp_idx]
-
-            ### Initialize final idx for sorting
-            temp_sort_idx = np.arange(0, len(temp_idx))
-
-            if len(temp_idx) < 2:
-                end_idx = start_idx + len(temp_idx)
-                sort_idx[start_idx:end_idx] = temp_idx
-                start_idx = end_idx
-                continue
-
-            ### Correct attack collisions by adding in health
-            temp_health = health[temp_idx]
-            temp_stats = temp_attack + temp_health
-            temp_start_idx = 0
-            for ustats in np.unique(temp_stats)[::-1]:
-                temp_sidx = np.where(temp_stats == ustats)[0]
-                temp_sidx = np.random.choice(
-                    temp_sidx, size=(len(temp_sidx),), replace=False
-                )
-                temp_end_idx = temp_start_idx + len(temp_sidx)
-                temp_sort_idx[temp_start_idx:temp_end_idx] = temp_sidx
-                temp_start_idx = temp_end_idx
-
-            ### Double check algorithm
-            sorted_attack = [temp_attack[x] for x in temp_sort_idx]
-            sorted_health = [temp_health[x] for x in temp_sort_idx]
-            for iter_idx, tempa in enumerate(sorted_attack[1:-1]):
-                iter_idx += 1
-                if tempa < sorted_attack[iter_idx]:
-                    raise Exception("That's impossible. Sorting issue.")
-            for iter_idx, temph in enumerate(sorted_health[1:-1]):
-                iter_idx += 1
-                if temph < sorted_health[iter_idx]:
-                    raise Exception("That's impossible. Sorting issue.")
-
-            ### Dereference temp_sort_idx and store in sort_idx
-            end_idx = start_idx + len(temp_idx)
-            sort_idx[start_idx:end_idx] = temp_idx
-            start_idx = end_idx
-
-        ### Finish sorting by max attack
-        attack = np.array([attack[x] for x in sort_idx])
-        health = np.array([health[x] for x in sort_idx])
-        teams = np.array([teams[x] for x in sort_idx])
-        idx = np.array([idx[x] for x in sort_idx])
-
-        ### Double check sorting algorithm
-        for iter_idx, tempa in enumerate(attack[1:-1]):
-            iter_idx += 2
-            if tempa < attack[iter_idx]:
-                raise Exception("That's impossible. Sorting issue.")
-
-        ### Build final queue
-        pet_priority = []
-        pet_priority_pets = []
-        for t, i in zip(teams, idx):
-            if [self.t0, self.t1][t][i].empty == True:
-                continue
-            pet_priority.append((t, i))
-
-        return pet_priority
+        return [(idx // 5, idx % 5) for idx in index]
 
 
 class RBattle(Battle):

--- a/sapai/pets.py
+++ b/sapai/pets.py
@@ -22,7 +22,7 @@ class Pet:
 
         if len(name) != 0:
             if not name.startswith("pet-"):
-                name = "pet-{}".format(name)
+                name = f"pet-{name}"
         self.seed_state = seed_state
         if self.seed_state != None:
             self.rs = np.random.RandomState()
@@ -41,7 +41,7 @@ class Pet:
 
         self.name = name
         if name not in data["pets"]:
-            raise Exception("Pet {} not found".format(name))
+            raise Exception(f"Pet {name} not found")
         fd = data["pets"][name]
         self.fd = fd
         self.override_ability = False
@@ -105,8 +105,8 @@ class Pet:
     def ability(self):
         if self.override_ability:
             return self.override_ability_dict
-        if "level{}Ability".format(self.level) in self.fd:
-            return self.fd["level{}Ability".format(self.level)]
+        if f"level{self.level}Ability" in self.fd:
+            return self.fd[f"level{self.level}Ability"]
         else:
             return empty_ability
 
@@ -366,7 +366,7 @@ class Pet:
                 if trigger == self:
                     return activated, targets, possible
             else:
-                raise Exception("Ability unrecognized for {}".format(self))
+                raise Exception(f"Ability unrecognized for {self}")
 
         ### Behavior for BuyTier1Animal
         if self.ability["trigger"] == "BuyTier1Animal":
@@ -500,9 +500,7 @@ class Pet:
                 return activated, targets, possible
         else:
             if self.ability["trigger"] != "EndOfTurn":
-                raise Exception(
-                    "Unrecognized trigger {}".format(self.ability["trigger"])
-                )
+                raise Exception(f"Unrecognized trigger {self.ability['trigger']}")
 
         if "maxTriggers" in self.ability:
             if self.ability_counter >= self.ability["maxTriggers"]:
@@ -863,13 +861,9 @@ class Pet:
         return activated, targets, possible
 
     def __repr__(self):
-        return "< {} {}-{} {} {}-{} >".format(
-            self.name,
-            self._attack,
-            self._health,
-            self.status,
-            self.level,
-            self.experience,
+        return (
+            f"< {self.name} {self._attack}-{self._health} "
+            + f"{self.status} {self.level}-{self.experience} >"
         )
 
     def copy(self):

--- a/sapai/player.py
+++ b/sapai/player.py
@@ -238,7 +238,7 @@ class Player:
 
         ### Check if any animals fainted because of pill and if any other
         ### animals fainted because of those animals fainting
-        pp = Battle.update_pet_priority(self.team, Team())  # no enemy team in shop
+        pp = Battle(self.team, Team()).calculate_pet_priority()  # no enemy team in shop
         status_list = []
         while True:
             ### Get a list of fainted pets
@@ -293,7 +293,7 @@ class Player:
                     hurt_list.append(pet_idx)
                     activated, targets, possible = p.hurt_trigger(Team())
 
-            pp = Battle.update_pet_priority(self.team, Team())
+            pp = Battle(self.team, Team()).calculate_pet_priority()
 
             ### if nothing happend, stop the loop
             if len(fainted_list) == 0 and len(hurt_list) == 0:

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -55,7 +55,7 @@ class PetPriorityTestCase(unittest.TestCase):
         self.assertEqual(priority, ref_priority)
 
     def test_no_level_priority(self):
-        """Tests priority is not determined by health"""
+        """Tests priority is not determined by level"""
         t0 = Team(["sloth", "sloth", "sloth", "sloth", "sloth"])
         t1 = Team(["sloth", "sloth", "sloth", "sloth", "sloth"])
         battle = Battle(t0, t1)
@@ -70,452 +70,452 @@ class PetPriorityTestCase(unittest.TestCase):
         self.assertEqual(priority, ref_priority)
 
 
-# class TestBattles(unittest.TestCase):
-#     def test_multi_hurt(self):
-#         seed_state = np.random.RandomState(seed=3).get_state()
-#         t0 = Team(["badger", "camel", "fish"], seed_state=seed_state)
-#         t0[0].pet._health = 1
-#         t0[0].pet._attack = 1
-#         t1 = Team(["cricket", "mosquito", "tiger"], seed_state=seed_state)
-
-#         b = Battle(t0, t1)
-#         b.battle()
-
-#         ### For this seed, enemy mosquito hits camel and badger
-#         ### Camel will activate for mosquito, badger, cricket, zombie cricket
-#         camel_buff = 2 * 4
-#         tiger_attack = t1[2].obj.attack
-#         self.assertEqual(len(b.t1.filled), 0)
-#         self.assertEqual(b.t0[0].health, 2 + camel_buff - tiger_attack)
-#         self.assertEqual(b.t0[0].attack, 2 + camel_buff)
-
-#     def test_multi_faint(self):
-#         t0 = Team(["badger", "camel", "fish"])
-#         t0[0].pet._health = 1
-#         t0[0].pet._attack = 6
-#         t0[0].pet.level = 2
-#         t1 = Team(["cricket", "horse", "mosquito", "tiger"])
-
-#         b = Battle(t0, t1)
-#         b.attack()
-
-#         ### Cricket will kill badger, badger faint should kill camel and horse
-
-#     def test_before_and_after_attack(self):
-#         t0 = Team(["elephant", "snake", "dragon", "fish"])
-#         t1 = Team(["cricket", "horse", "fly", "tiger"])
-#         t0[2]._health = 50
-
-#         b = Battle(t0, t1)
-#         b.battle()
-#         t0 = Team(["elephant", "snake", "dragon", "fish"])
-#         t1 = Team(["cricket", "horse", "fly", "tiger"])
-#         t0[2]._health = 50
-
-#         b = Battle(t0, t1)
-#         b.battle()
-
-#     def test_rhino_test(self):
-#         t0 = Team(["horse", "horse", "horse", "horse"])
-#         t1 = Team(["rhino", "tiger"])
-
-#         b = Battle(t0, t1)
-#         b.battle()
-
-#     def test_hippo_test(self):
-#         t0 = Team(["horse", "horse", "horse", "horse"])
-#         t1 = Team(["hippo", "tiger"])
-
-#         b = Battle(t0, t1)
-#         b.battle()
-
-#     def test_whale_without_swallow_target(self):
-#         team1 = Team([Pet("fish")])
-#         team2 = Team([Pet("whale"), Pet("hedgehog"), Pet("fish"), Pet("rabbit")])
-
-#         test_battle = Battle(team1, team2)
-#         test_battle.battle()
-
-#     def test_cat_battle(self):
-#         team1 = Team([Pet("fish")])
-#         team2 = Team([Pet("cat")])
-
-#         test_battle = Battle(team1, team2)
-#         test_battle.battle()
-
-#     def test_multiple_hedgehog(self):
-#         team1 = Team([Pet("fish"), Pet("hedgehog")])
-#         team2 = Team([Pet("elephant"), Pet("hedgehog")])
-
-#         test_battle = Battle(team1, team2)
-#         test_battle.battle()
-
-#     def test_whale_parrot_swallow(self):
-#         team1 = Team([Pet("whale"), Pet("parrot")])
-#         team2 = Team([Pet("fish"), "dragon"])
-
-#         player1 = Player(team=team1)
-#         player2 = Player(team=team2)
-
-#         player1.end_turn()
-#         player2.end_turn()
-
-#         test_battle = Battle(player1.team, player2.team)
-#         test_battle.battle()
-
-#     def test_caterpillar_order_high_attack(self):
-#         cp = Pet("caterpillar")
-#         cp.level = 3
-#         cp._attack = 5  # 1 more than dolphin
-#         cp._health = 7
-#         t = Team([cp, "dragon"])
-#         t2 = Team(["dolphin", "dragon"])
-#         b = Battle(t, t2)
-#         r = b.battle()
-#         # print(b.battle_history) # caterpillar evolves first, dolphin snipes butterfly, 1v2 loss
-#         self.assertEqual(r, 1)
-
-#     def test_caterpillar_order_low_attack(self):
-#         cp = Pet("caterpillar")
-#         cp.level = 3
-#         cp._attack = 1
-#         cp._health = 7
-#         t = Team([cp, "dragon"])
-#         t2 = Team(["dolphin", "dragon"])
-#         b = Battle(t, t2)
-#         r = b.battle()
-#         # print(b.battle_history) # dolphin hits caterpillar, caterpillar evolves, copies dragon, win
-#         self.assertEqual(r, 0)
-
-#     def test_dodo(self):
-#         dodo = Pet("dodo")
-#         dodo.level = 3
-#         dodo._attack = 10
-#         team1 = Team([Pet("leopard"), dodo])
-
-#         fish = Pet("fish")
-#         fish._attack = 5
-#         fish._health = 20
-#         team2 = Team([fish])
-
-#         test_battle = Battle(team1, team2)
-#         result = test_battle.battle()
-
-#         # dodo adds enough attack for leopard to kill fish
-#         self.assertEqual(result, 0)
-
-#     def test_ant_in_battle(self):
-#         team1 = Team([Pet("ant"), Pet("fish")])
-#         team2 = Team([Pet("camel")])
-
-#         test_battle = Battle(team1, team2)
-#         result = test_battle.battle()
-#         self.assertEqual(result, 0)
-
-#     def test_horse_in_battle(self):
-#         team1 = Team([Pet("cricket"), Pet("horse")])
-#         team2 = Team([Pet("camel")])
-
-#         test_battle = Battle(team1, team2)
-#         result = test_battle.battle()
-#         self.assertEqual(test_battle.t0.empty, [0, 1, 2, 3, 4])
-#         self.assertEqual(test_battle.t1[0].health, 1)
-
-#     def test_horse_with_bee_in_battle(self):
-#         cricket = Pet("cricket")
-#         cricket.status = "status-honey-bee"
-#         team1 = Team([cricket, Pet("horse")])
-#         fish = Pet("fish")
-#         fish._health = 5
-#         team2 = Team([fish, Pet("beaver")])
-
-#         test_battle = Battle(team1, team2)
-#         result = test_battle.battle()
-#         self.assertEqual(result, 2)
-
-#     def test_mosquito_in_battle(self):
-#         team1 = Team([Pet("mosquito")])
-#         team2 = Team([Pet("pig")])
-
-#         test_battle = Battle(team1, team2)
-#         result = test_battle.battle()
-#         self.assertEqual(result, 0)
-
-#     def test_blowfish_pingpong(self):
-#         # they hit eachother once, rest of the battle is constant hurt triggers until they both faint
-#         b1 = Pet("blowfish")
-#         b1._attack = 1
-#         b1._health = 50
-
-#         b2 = Pet("blowfish")
-#         b2._attack = 1
-#         b2._health = 50
-
-#         b = Battle(Team([b1]), Team([b2]))
-#         r = b.battle()
-#         self.assertTrue(
-#             "attack 1" not in b.battle_history
-#         )  # they attack eachother, then keep using hurt_triggers until one of them dies, should never reach a 2nd attack phase
-
-#     def test_elephant_blowfish(self):
-#         # blowfish snipes first fish in 'before-attack' phase of elephant, leaving elephant without a target to attack normally
-#         # then snipes second fish in next turn's 'before attack'
-#         state = np.random.RandomState(seed=1).get_state()
-
-#         e1 = Pet("elephant")
-#         e1._attack = 1
-#         e1._health = 5
-
-#         b1 = Pet("blowfish", seed_state=state)
-#         b1._attack = 1
-#         b1._health = 5
-
-#         f1 = Pet("fish")
-#         f1._attack = 50
-#         f1._health = 1
-#         f1.status = "status-splash-attack"
-
-#         f2 = Pet("fish")
-#         f2._attack = 50
-#         f2._health = 1
-#         f2.status = "status-splash-attack"
-
-#         b = Battle(Team([e1, b1]), Team([f1, f2]))
-#         r = b.battle()
-#         self.assertEqual(r, 0)
-
-#     def test_hedgehog_blowfish_camel_hurt_team(self):
-#         # standard hedgehog blowfish camel teams facing off against eachother
-#         # lots of hurt triggers going off within one turn
-#         state1 = np.random.RandomState(seed=2).get_state()
-#         state2 = np.random.RandomState(seed=2).get_state()
-
-#         bf1 = Pet("blowfish", seed_state=state1)
-#         bf1._attack = 20
-#         bf1._health = 20
-#         bf1.level = 3
-#         bf1.status = "status-garlic-armor"
-
-#         c1 = Pet("camel")
-#         c1._attack = 20
-#         c1._health = 20
-#         c1.level = 2
-#         c1.status = "status-garlic-armor"
-
-#         hh1 = Pet("hedgehog")
-#         hh2 = Pet("hedgehog")
-
-#         bf2 = Pet("blowfish", seed_state=state2)
-#         bf2._attack = 20
-#         bf2._health = 20
-#         bf2.level = 3
-#         bf2.status = "status-garlic-armor"
-
-#         c2 = Pet("camel")
-#         c2._attack = 20
-#         c2._health = 20
-#         c2.level = 2
-#         c2.status = "status-garlic-armor"
-
-#         hh3 = Pet("hedgehog")
-#         hh4 = Pet("hedgehog")
-
-#         b = Battle(Team([hh1, hh2, c1, bf1]), Team([hh3, hh4, c2, bf2]))
-#         r = b.battle()
-#         self.assertEqual(r, 2)
-
-#     def test_hedgehog_vs_honey(self):
-#         hh1 = Pet("hedgehog")
-#         hh2 = Pet("hedgehog")
-#         hh3 = Pet("hedgehog")
-#         hh4 = Pet("hedgehog")
-#         hh5 = Pet("hedgehog")
-#         f1 = Pet("fish")
-#         f1.status = "status-honey-bee"
-
-#         b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
-#         r = b.battle()
-#         # ability triggers always go before status triggers
-#         # fish wins since honey bee spawns at the end of the turn, after all faint triggers are completed
-#         self.assertEqual(r, 1)
-
-#     def test_hedgehog_vs_mushroom(self):
-#         hh1 = Pet("hedgehog")
-#         hh2 = Pet("hedgehog")
-#         hh3 = Pet("hedgehog")
-#         hh4 = Pet("hedgehog")
-#         hh5 = Pet("hedgehog")
-#         f1 = Pet("fish")
-#         f1.status = "status-extra-life"
-
-#         b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
-#         r = b.battle()
-#         # ability triggers always go before status triggers
-#         # fish wins since mushroom spawns at the end of the turn, after all faint triggers are completed
-#         self.assertEqual(r, 1)
-
-#     def test_mushroom_scorpion(self):
-#         scorpion = Pet("scorpion")
-#         scorpion.status = "status-extra-life"
-#         b = Battle(Team([scorpion]), Team(["dragon"]))
-#         r = b.battle()
-#         self.assertEqual(r, 2)  # draw since scorpion respawns with poison.
-
-#     def test_badger_draws(self):
-#         # normal 1v1
-#         b1 = Pet("badger")
-#         b2 = Pet("badger")
-#         b = Battle(Team([b1]), Team([b2]))
-#         r = b.battle()
-#         self.assertEqual(r, 2)
-
-#         # 1 survives, enemy ability kills
-#         b1 = Pet("badger")
-#         b1._health = 6
-#         b2 = Pet("badger")
-#         b = Battle(Team([b1]), Team([b2]))
-#         r = b.battle()
-#         self.assertEqual(r, 2)
-
-#         # normal honey 1v1
-#         hb1 = Pet("badger")
-#         hb1.status = "status-honey-bee"
-#         hb2 = Pet("badger")
-#         hb2.status = "status-honey-bee"
-#         b = Battle(Team([hb1]), Team([hb2]))
-#         r = b.battle()
-#         self.assertEqual(r, 2)
-
-#         # 1 survives, enemy ability kills
-#         hb1 = Pet("badger")
-#         hb1.status = "status-honey-bee"
-#         hb1._health = 6
-#         hb2 = Pet("badger")
-#         hb2.status = "status-honey-bee"
-#         b = Battle(Team([hb1]), Team([hb2]))
-#         r = b.battle()
-#         self.assertEqual(r, 2)
-
-#         # 1 survives, enemey ability kills, even with less attack priority should NOT be able to hit bee with ability
-#         hb1 = Pet("badger")
-#         hb1.status = "status-honey-bee"
-#         hb1._attack = 4
-#         hb1._health = 6
-#         hb2 = Pet("badger")
-#         hb2.status = "status-honey-bee"
-#         b = Battle(Team([hb1]), Team([hb2]))
-#         r = b.battle()
-#         self.assertEqual(r, 2)
-
-#         # badger with less attack can kill zombie-cricket
-#         b1 = Pet("badger")
-#         c1 = Pet("cricket")
-#         c1._attack = 6
-#         b = Battle(Team([b1]), Team([c1]))
-#         r = b.battle()
-#         self.assertEqual(r, 2)
-
-#         # badger with higher priority hits nothing with ability, zombie-cricket spanws and bee spawns
-#         hb1 = Pet("badger")
-#         hb1.status = "status-honey-bee"
-#         c1 = Pet("cricket")
-#         c1._attack = 4
-#         b = Battle(Team([hb1]), Team([c1]))
-#         r = b.battle()
-#         self.assertEqual(r, 2)
-
-#     def test_badger_wins(self):
-#         # bee win
-#         hb1 = Pet("badger")
-#         hb1.status = "status-honey-bee"
-#         b2 = Pet("badger")
-#         b = Battle(Team([hb1]), Team([b2]))
-#         r = b.battle()
-#         self.assertEqual(r, 0)
-
-#         # badger with higher priority hits nothing with ability, zombie-cricket spanws and wins
-#         c1 = Pet("cricket")
-#         c1._attack = 4
-#         b1 = Pet("badger")
-#         b = Battle(Team([c1]), Team([b1]))
-#         r = b.battle()
-#         self.assertEqual(r, 0)
-
-#         # badger with less attack can kill zombie-cricket, then bee spawns
-#         hb1 = Pet("badger")
-#         hb1.status = "status-honey-bee"
-#         c1 = Pet("cricket")
-#         c1._attack = 6
-#         b = Battle(Team([hb1]), Team([c1]))
-#         r = b.battle()
-#         self.assertEqual(r, 0)
-
-#     def test_rat_summons_at_front(self):
-#         team1 = Team(["rat", "blowfish"])
-#         fish = Pet("fish")
-#         fish._attack = 5
-#         big_attack_pet = Pet("beaver")
-#         big_attack_pet._attack = 50
-#         team2 = Team([fish, big_attack_pet])
-
-#         test_battle = Battle(team1, team2)
-#         result = test_battle.battle()
-#         self.assertEqual(result, 0)
-
-#     def test_badger(self):
-#         seed_state = np.random.RandomState(seed=1).get_state()
-#         badger_frac = [None, 0.5, 1.0, 1.5]
-#         ### Testing that badger damage is correct across entire relevant range
-#         for l in range(1, 4):
-#             for i in range(1, 50):
-#                 t0 = Team(["badger", "fish", "fish"], seed_state=seed_state)
-#                 t0[0].obj.level = l
-#                 t0[0].obj._attack = i
-#                 t0[0].obj._health = 1
-#                 t1 = Team(["mosquito", "fish"], seed_state=seed_state)
-#                 t0[0].obj.hurt(1)
-#                 activated, targets, _ = t0[0].obj.faint_trigger(
-#                     t0[0].obj, [0, 0], oteam=t1
-#                 )
-
-#                 badger_damage = max(int(i * badger_frac[l]), 1)
-#                 self.assertTrue(activated)
-#                 self.assertEqual(targets, [t1[0].obj, t0[1].obj])
-#                 self.assertEqual(t0[1].obj.health, 2 - badger_damage)
-#                 self.assertEqual(t1[0].obj.health, 2 - badger_damage)
-#                 self.assertEqual(t0[2].obj.health, 2)
-#                 self.assertEqual(t1[1].obj.health, 2)
-
-#         ### Testing badger damage is correct for different positions
-#         t0 = Team(["fish", "badger", "fish"], seed_state=seed_state)
-#         t0[1].obj.level = 2
-#         t0[1].obj._attack = 4
-#         t0[1].obj._health = 1
-#         t1 = Team(["mosquito", "fish"], seed_state=seed_state)
-#         t0[1].obj.hurt(1)
-#         activated, targets, _ = t0[1].obj.faint_trigger(t0[1].obj, [0, 1], oteam=t1)
-#         badger_damage = 4
-#         self.assertEqual(targets, [t0[0].obj, t0[2].obj])
-#         self.assertEqual(t0[0].obj.health, 2 - 4)
-#         self.assertEqual(t0[2].obj.health, 2 - 4)
-
-#         t0 = Team(["fish", "fish", "badger"], seed_state=seed_state)
-#         t0[2].obj.level = 2
-#         t0[2].obj._attack = 4
-#         t0[2].obj._health = 1
-#         t1 = Team(["mosquito", "fish"], seed_state=seed_state)
-#         t0[2].obj.hurt(1)
-#         activated, targets, _ = t0[2].obj.faint_trigger(t0[2].obj, [0, 2], oteam=t1)
-#         badger_damage = 4
-#         self.assertEqual(targets, [t0[1].obj])
-#         self.assertEqual(t0[1].obj.health, 2 - 4)
-
-#     def test_peacock(self):
-#         ### Check that peacock attack is correct after battle
-
-#         ### Check peacock attack after elephant for all three levels
-
-#         ### Check peacock after headgehog on both teams
-
-#         ### Implement later with others
-#         pass
+class TestBattles(unittest.TestCase):
+    def test_multi_hurt(self):
+        seed_state = np.random.RandomState(seed=3).get_state()
+        t0 = Team(["badger", "camel", "fish"], seed_state=seed_state)
+        t0[0].pet._health = 1
+        t0[0].pet._attack = 1
+        t1 = Team(["cricket", "mosquito", "tiger"], seed_state=seed_state)
+
+        b = Battle(t0, t1)
+        b.battle()
+
+        ### For this seed, enemy mosquito hits camel and badger
+        ### Camel will activate for mosquito, badger, cricket, zombie cricket
+        camel_buff = 2 * 4
+        tiger_attack = t1[2].obj.attack
+        self.assertEqual(len(b.t1.filled), 0)
+        self.assertEqual(b.t0[0].health, 2 + camel_buff - tiger_attack)
+        self.assertEqual(b.t0[0].attack, 2 + camel_buff)
+
+    def test_multi_faint(self):
+        t0 = Team(["badger", "camel", "fish"])
+        t0[0].pet._health = 1
+        t0[0].pet._attack = 6
+        t0[0].pet.level = 2
+        t1 = Team(["cricket", "horse", "mosquito", "tiger"])
+
+        b = Battle(t0, t1)
+        b.attack()
+
+        ### Cricket will kill badger, badger faint should kill camel and horse
+
+    def test_before_and_after_attack(self):
+        t0 = Team(["elephant", "snake", "dragon", "fish"])
+        t1 = Team(["cricket", "horse", "fly", "tiger"])
+        t0[2]._health = 50
+
+        b = Battle(t0, t1)
+        b.battle()
+        t0 = Team(["elephant", "snake", "dragon", "fish"])
+        t1 = Team(["cricket", "horse", "fly", "tiger"])
+        t0[2]._health = 50
+
+        b = Battle(t0, t1)
+        b.battle()
+
+    def test_rhino_test(self):
+        t0 = Team(["horse", "horse", "horse", "horse"])
+        t1 = Team(["rhino", "tiger"])
+
+        b = Battle(t0, t1)
+        b.battle()
+
+    def test_hippo_test(self):
+        t0 = Team(["horse", "horse", "horse", "horse"])
+        t1 = Team(["hippo", "tiger"])
+
+        b = Battle(t0, t1)
+        b.battle()
+
+    def test_whale_without_swallow_target(self):
+        team1 = Team([Pet("fish")])
+        team2 = Team([Pet("whale"), Pet("hedgehog"), Pet("fish"), Pet("rabbit")])
+
+        test_battle = Battle(team1, team2)
+        test_battle.battle()
+
+    def test_cat_battle(self):
+        team1 = Team([Pet("fish")])
+        team2 = Team([Pet("cat")])
+
+        test_battle = Battle(team1, team2)
+        test_battle.battle()
+
+    def test_multiple_hedgehog(self):
+        team1 = Team([Pet("fish"), Pet("hedgehog")])
+        team2 = Team([Pet("elephant"), Pet("hedgehog")])
+
+        test_battle = Battle(team1, team2)
+        test_battle.battle()
+
+    def test_whale_parrot_swallow(self):
+        team1 = Team([Pet("whale"), Pet("parrot")])
+        team2 = Team([Pet("fish"), "dragon"])
+
+        player1 = Player(team=team1)
+        player2 = Player(team=team2)
+
+        player1.end_turn()
+        player2.end_turn()
+
+        test_battle = Battle(player1.team, player2.team)
+        test_battle.battle()
+
+    def test_caterpillar_order_high_attack(self):
+        cp = Pet("caterpillar")
+        cp.level = 3
+        cp._attack = 5  # 1 more than dolphin
+        cp._health = 7
+        t = Team([cp, "dragon"])
+        t2 = Team(["dolphin", "dragon"])
+        b = Battle(t, t2)
+        r = b.battle()
+        # print(b.battle_history) # caterpillar evolves first, dolphin snipes butterfly, 1v2 loss
+        self.assertEqual(r, 1)
+
+    def test_caterpillar_order_low_attack(self):
+        cp = Pet("caterpillar")
+        cp.level = 3
+        cp._attack = 1
+        cp._health = 7
+        t = Team([cp, "dragon"])
+        t2 = Team(["dolphin", "dragon"])
+        b = Battle(t, t2)
+        r = b.battle()
+        # print(b.battle_history) # dolphin hits caterpillar, caterpillar evolves, copies dragon, win
+        self.assertEqual(r, 0)
+
+    def test_dodo(self):
+        dodo = Pet("dodo")
+        dodo.level = 3
+        dodo._attack = 10
+        team1 = Team([Pet("leopard"), dodo])
+
+        fish = Pet("fish")
+        fish._attack = 5
+        fish._health = 20
+        team2 = Team([fish])
+
+        test_battle = Battle(team1, team2)
+        result = test_battle.battle()
+
+        # dodo adds enough attack for leopard to kill fish
+        self.assertEqual(result, 0)
+
+    def test_ant_in_battle(self):
+        team1 = Team([Pet("ant"), Pet("fish")])
+        team2 = Team([Pet("camel")])
+
+        test_battle = Battle(team1, team2)
+        result = test_battle.battle()
+        self.assertEqual(result, 0)
+
+    def test_horse_in_battle(self):
+        team1 = Team([Pet("cricket"), Pet("horse")])
+        team2 = Team([Pet("camel")])
+
+        test_battle = Battle(team1, team2)
+        result = test_battle.battle()
+        self.assertEqual(test_battle.t0.empty, [0, 1, 2, 3, 4])
+        self.assertEqual(test_battle.t1[0].health, 1)
+
+    def test_horse_with_bee_in_battle(self):
+        cricket = Pet("cricket")
+        cricket.status = "status-honey-bee"
+        team1 = Team([cricket, Pet("horse")])
+        fish = Pet("fish")
+        fish._health = 5
+        team2 = Team([fish, Pet("beaver")])
+
+        test_battle = Battle(team1, team2)
+        result = test_battle.battle()
+        self.assertEqual(result, 2)
+
+    def test_mosquito_in_battle(self):
+        team1 = Team([Pet("mosquito")])
+        team2 = Team([Pet("pig")])
+
+        test_battle = Battle(team1, team2)
+        result = test_battle.battle()
+        self.assertEqual(result, 0)
+
+    def test_blowfish_pingpong(self):
+        # they hit eachother once, rest of the battle is constant hurt triggers until they both faint
+        b1 = Pet("blowfish")
+        b1._attack = 1
+        b1._health = 50
+
+        b2 = Pet("blowfish")
+        b2._attack = 1
+        b2._health = 50
+
+        b = Battle(Team([b1]), Team([b2]))
+        r = b.battle()
+        self.assertTrue(
+            "attack 1" not in b.battle_history
+        )  # they attack eachother, then keep using hurt_triggers until one of them dies, should never reach a 2nd attack phase
+
+    def test_elephant_blowfish(self):
+        # blowfish snipes first fish in 'before-attack' phase of elephant, leaving elephant without a target to attack normally
+        # then snipes second fish in next turn's 'before attack'
+        state = np.random.RandomState(seed=1).get_state()
+
+        e1 = Pet("elephant")
+        e1._attack = 1
+        e1._health = 5
+
+        b1 = Pet("blowfish", seed_state=state)
+        b1._attack = 1
+        b1._health = 5
+
+        f1 = Pet("fish")
+        f1._attack = 50
+        f1._health = 1
+        f1.status = "status-splash-attack"
+
+        f2 = Pet("fish")
+        f2._attack = 50
+        f2._health = 1
+        f2.status = "status-splash-attack"
+
+        b = Battle(Team([e1, b1]), Team([f1, f2]))
+        r = b.battle()
+        self.assertEqual(r, 0)
+
+    def test_hedgehog_blowfish_camel_hurt_team(self):
+        # standard hedgehog blowfish camel teams facing off against eachother
+        # lots of hurt triggers going off within one turn
+        state1 = np.random.RandomState(seed=2).get_state()
+        state2 = np.random.RandomState(seed=2).get_state()
+
+        bf1 = Pet("blowfish", seed_state=state1)
+        bf1._attack = 20
+        bf1._health = 20
+        bf1.level = 3
+        bf1.status = "status-garlic-armor"
+
+        c1 = Pet("camel")
+        c1._attack = 20
+        c1._health = 20
+        c1.level = 2
+        c1.status = "status-garlic-armor"
+
+        hh1 = Pet("hedgehog")
+        hh2 = Pet("hedgehog")
+
+        bf2 = Pet("blowfish", seed_state=state2)
+        bf2._attack = 20
+        bf2._health = 20
+        bf2.level = 3
+        bf2.status = "status-garlic-armor"
+
+        c2 = Pet("camel")
+        c2._attack = 20
+        c2._health = 20
+        c2.level = 2
+        c2.status = "status-garlic-armor"
+
+        hh3 = Pet("hedgehog")
+        hh4 = Pet("hedgehog")
+
+        b = Battle(Team([hh1, hh2, c1, bf1]), Team([hh3, hh4, c2, bf2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+    def test_hedgehog_vs_honey(self):
+        hh1 = Pet("hedgehog")
+        hh2 = Pet("hedgehog")
+        hh3 = Pet("hedgehog")
+        hh4 = Pet("hedgehog")
+        hh5 = Pet("hedgehog")
+        f1 = Pet("fish")
+        f1.status = "status-honey-bee"
+
+        b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
+        r = b.battle()
+        # ability triggers always go before status triggers
+        # fish wins since honey bee spawns at the end of the turn, after all faint triggers are completed
+        self.assertEqual(r, 1)
+
+    def test_hedgehog_vs_mushroom(self):
+        hh1 = Pet("hedgehog")
+        hh2 = Pet("hedgehog")
+        hh3 = Pet("hedgehog")
+        hh4 = Pet("hedgehog")
+        hh5 = Pet("hedgehog")
+        f1 = Pet("fish")
+        f1.status = "status-extra-life"
+
+        b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
+        r = b.battle()
+        # ability triggers always go before status triggers
+        # fish wins since mushroom spawns at the end of the turn, after all faint triggers are completed
+        self.assertEqual(r, 1)
+
+    def test_mushroom_scorpion(self):
+        scorpion = Pet("scorpion")
+        scorpion.status = "status-extra-life"
+        b = Battle(Team([scorpion]), Team(["dragon"]))
+        r = b.battle()
+        self.assertEqual(r, 2)  # draw since scorpion respawns with poison.
+
+    def test_badger_draws(self):
+        # normal 1v1
+        b1 = Pet("badger")
+        b2 = Pet("badger")
+        b = Battle(Team([b1]), Team([b2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # 1 survives, enemy ability kills
+        b1 = Pet("badger")
+        b1._health = 6
+        b2 = Pet("badger")
+        b = Battle(Team([b1]), Team([b2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # normal honey 1v1
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        hb2 = Pet("badger")
+        hb2.status = "status-honey-bee"
+        b = Battle(Team([hb1]), Team([hb2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # 1 survives, enemy ability kills
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        hb1._health = 6
+        hb2 = Pet("badger")
+        hb2.status = "status-honey-bee"
+        b = Battle(Team([hb1]), Team([hb2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # 1 survives, enemey ability kills, even with less attack priority should NOT be able to hit bee with ability
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        hb1._attack = 4
+        hb1._health = 6
+        hb2 = Pet("badger")
+        hb2.status = "status-honey-bee"
+        b = Battle(Team([hb1]), Team([hb2]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # badger with less attack can kill zombie-cricket
+        b1 = Pet("badger")
+        c1 = Pet("cricket")
+        c1._attack = 6
+        b = Battle(Team([b1]), Team([c1]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+        # badger with higher priority hits nothing with ability, zombie-cricket spanws and bee spawns
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        c1 = Pet("cricket")
+        c1._attack = 4
+        b = Battle(Team([hb1]), Team([c1]))
+        r = b.battle()
+        self.assertEqual(r, 2)
+
+    def test_badger_wins(self):
+        # bee win
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        b2 = Pet("badger")
+        b = Battle(Team([hb1]), Team([b2]))
+        r = b.battle()
+        self.assertEqual(r, 0)
+
+        # badger with higher priority hits nothing with ability, zombie-cricket spanws and wins
+        c1 = Pet("cricket")
+        c1._attack = 4
+        b1 = Pet("badger")
+        b = Battle(Team([c1]), Team([b1]))
+        r = b.battle()
+        self.assertEqual(r, 0)
+
+        # badger with less attack can kill zombie-cricket, then bee spawns
+        hb1 = Pet("badger")
+        hb1.status = "status-honey-bee"
+        c1 = Pet("cricket")
+        c1._attack = 6
+        b = Battle(Team([hb1]), Team([c1]))
+        r = b.battle()
+        self.assertEqual(r, 0)
+
+    def test_rat_summons_at_front(self):
+        team1 = Team(["rat", "blowfish"])
+        fish = Pet("fish")
+        fish._attack = 5
+        big_attack_pet = Pet("beaver")
+        big_attack_pet._attack = 50
+        team2 = Team([fish, big_attack_pet])
+
+        test_battle = Battle(team1, team2)
+        result = test_battle.battle()
+        self.assertEqual(result, 0)
+
+    def test_badger(self):
+        seed_state = np.random.RandomState(seed=1).get_state()
+        badger_frac = [None, 0.5, 1.0, 1.5]
+        ### Testing that badger damage is correct across entire relevant range
+        for l in range(1, 4):
+            for i in range(1, 50):
+                t0 = Team(["badger", "fish", "fish"], seed_state=seed_state)
+                t0[0].obj.level = l
+                t0[0].obj._attack = i
+                t0[0].obj._health = 1
+                t1 = Team(["mosquito", "fish"], seed_state=seed_state)
+                t0[0].obj.hurt(1)
+                activated, targets, _ = t0[0].obj.faint_trigger(
+                    t0[0].obj, [0, 0], oteam=t1
+                )
+
+                badger_damage = max(int(i * badger_frac[l]), 1)
+                self.assertTrue(activated)
+                self.assertEqual(targets, [t1[0].obj, t0[1].obj])
+                self.assertEqual(t0[1].obj.health, 2 - badger_damage)
+                self.assertEqual(t1[0].obj.health, 2 - badger_damage)
+                self.assertEqual(t0[2].obj.health, 2)
+                self.assertEqual(t1[1].obj.health, 2)
+
+        ### Testing badger damage is correct for different positions
+        t0 = Team(["fish", "badger", "fish"], seed_state=seed_state)
+        t0[1].obj.level = 2
+        t0[1].obj._attack = 4
+        t0[1].obj._health = 1
+        t1 = Team(["mosquito", "fish"], seed_state=seed_state)
+        t0[1].obj.hurt(1)
+        activated, targets, _ = t0[1].obj.faint_trigger(t0[1].obj, [0, 1], oteam=t1)
+        badger_damage = 4
+        self.assertEqual(targets, [t0[0].obj, t0[2].obj])
+        self.assertEqual(t0[0].obj.health, 2 - 4)
+        self.assertEqual(t0[2].obj.health, 2 - 4)
+
+        t0 = Team(["fish", "fish", "badger"], seed_state=seed_state)
+        t0[2].obj.level = 2
+        t0[2].obj._attack = 4
+        t0[2].obj._health = 1
+        t1 = Team(["mosquito", "fish"], seed_state=seed_state)
+        t0[2].obj.hurt(1)
+        activated, targets, _ = t0[2].obj.faint_trigger(t0[2].obj, [0, 2], oteam=t1)
+        badger_damage = 4
+        self.assertEqual(targets, [t0[1].obj])
+        self.assertEqual(t0[1].obj.health, 2 - 4)
+
+    def test_peacock(self):
+        ### Check that peacock attack is correct after battle
+
+        ### Check peacock attack after elephant for all three levels
+
+        ### Check peacock after headgehog on both teams
+
+        ### Implement later with others
+        self.skipTest("TODO")

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -39,482 +39,483 @@ class PetPriorityTestCase(unittest.TestCase):
         result = Battle(t0, t1).calculate_pet_priority()
         self.assertEqual(result, [(1, 1), (1, 0), (0, 1), (0, 0)])
 
-    def test_health_priority(self):
-        """Tests priority determined by health (if attack is drawn)"""
-        t0 = Team(["sloth", "sloth"])
-        t0[0].pet._health = 1
-        t0[1].pet._health = 3
-        t1 = Team(["sloth"])
-        t1[0].pet._health = 2
-        result = Battle(t0, t1).calculate_pet_priority()
-        self.assertEqual(result, [(0, 1), (1, 0), (0, 0)])
+    def test_no_health_priority(self):
+        """Tests priority is not determined by health"""
+        t0 = Team(["sloth", "sloth", "sloth", "sloth", "sloth"])
+        t1 = Team(["sloth", "sloth", "sloth", "sloth", "sloth"])
+        battle = Battle(t0, t1)
+        ref_priority = battle.calculate_pet_priority(seed=0)
+        t0[0].pet._health = 50
+        t1[3].pet._health = 25
+        priority = battle.calculate_pet_priority(seed=0)
+        self.assertEqual(priority, ref_priority)
+        t0[0].pet._health = 25
+        t1[3].pet._health = 50
+        priority = battle.calculate_pet_priority(seed=0)
+        self.assertEqual(priority, ref_priority)
 
-        t0 = Team(["sloth", "sloth"])
-        t0[0].pet._health = 3
-        t0[1].pet._health = 2
-        t1 = Team(["sloth"])
-        t1[0].pet._health = 1
-        result = Battle(t0, t1).calculate_pet_priority()
-        self.assertEqual(result, [(0, 0), (0, 1), (1, 0)])
-
-        # level has no priority over health
-        t0 = Team(["sloth", "sloth"])
-        t0[0].pet._health = 1
+    def test_no_level_priority(self):
+        """Tests priority is not determined by health"""
+        t0 = Team(["sloth", "sloth", "sloth", "sloth", "sloth"])
+        t1 = Team(["sloth", "sloth", "sloth", "sloth", "sloth"])
+        battle = Battle(t0, t1)
+        ref_priority = battle.calculate_pet_priority(seed=0)
         t0[0].pet.level = 3
-        t0[1].pet._health = 2
-        t1 = Team(["sloth", "sloth"])
-        t1[0].pet._health = 3
-        t1[1].pet._health = 4
-        result = Battle(t0, t1).calculate_pet_priority()
-        self.assertEqual(result, [(1, 1), (1, 0), (0, 1), (0, 0)])
-
-
-class TestBattles(unittest.TestCase):
-    def test_multi_hurt(self):
-        seed_state = np.random.RandomState(seed=3).get_state()
-        t0 = Team(["badger", "camel", "fish"], seed_state=seed_state)
-        t0[0].pet._health = 1
-        t0[0].pet._attack = 1
-        t1 = Team(["cricket", "mosquito", "tiger"], seed_state=seed_state)
-
-        b = Battle(t0, t1)
-        b.battle()
-
-        ### For this seed, enemy mosquito hits camel and badger
-        ### Camel will activate for mosquito, badger, cricket, zombie cricket
-        camel_buff = 2 * 4
-        tiger_attack = t1[2].obj.attack
-        self.assertEqual(len(b.t1.filled), 0)
-        self.assertEqual(b.t0[0].health, 2 + camel_buff - tiger_attack)
-        self.assertEqual(b.t0[0].attack, 2 + camel_buff)
-
-    def test_multi_faint(self):
-        t0 = Team(["badger", "camel", "fish"])
-        t0[0].pet._health = 1
-        t0[0].pet._attack = 6
+        t1[3].pet.level = 2
+        priority = battle.calculate_pet_priority(seed=0)
+        self.assertEqual(priority, ref_priority)
         t0[0].pet.level = 2
-        t1 = Team(["cricket", "horse", "mosquito", "tiger"])
-
-        b = Battle(t0, t1)
-        b.attack()
-
-        ### Cricket will kill badger, badger faint should kill camel and horse
-
-    def test_before_and_after_attack(self):
-        t0 = Team(["elephant", "snake", "dragon", "fish"])
-        t1 = Team(["cricket", "horse", "fly", "tiger"])
-        t0[2]._health = 50
-
-        b = Battle(t0, t1)
-        b.battle()
-        t0 = Team(["elephant", "snake", "dragon", "fish"])
-        t1 = Team(["cricket", "horse", "fly", "tiger"])
-        t0[2]._health = 50
-
-        b = Battle(t0, t1)
-        b.battle()
-
-    def test_rhino_test(self):
-        t0 = Team(["horse", "horse", "horse", "horse"])
-        t1 = Team(["rhino", "tiger"])
-
-        b = Battle(t0, t1)
-        b.battle()
-
-    def test_hippo_test(self):
-        t0 = Team(["horse", "horse", "horse", "horse"])
-        t1 = Team(["hippo", "tiger"])
-
-        b = Battle(t0, t1)
-        b.battle()
-
-    def test_whale_without_swallow_target(self):
-        team1 = Team([Pet("fish")])
-        team2 = Team([Pet("whale"), Pet("hedgehog"), Pet("fish"), Pet("rabbit")])
-
-        test_battle = Battle(team1, team2)
-        test_battle.battle()
-
-    def test_cat_battle(self):
-        team1 = Team([Pet("fish")])
-        team2 = Team([Pet("cat")])
-
-        test_battle = Battle(team1, team2)
-        test_battle.battle()
-
-    def test_multiple_hedgehog(self):
-        team1 = Team([Pet("fish"), Pet("hedgehog")])
-        team2 = Team([Pet("elephant"), Pet("hedgehog")])
-
-        test_battle = Battle(team1, team2)
-        test_battle.battle()
-
-    def test_whale_parrot_swallow(self):
-        team1 = Team([Pet("whale"), Pet("parrot")])
-        team2 = Team([Pet("fish"), "dragon"])
-
-        player1 = Player(team=team1)
-        player2 = Player(team=team2)
-
-        player1.end_turn()
-        player2.end_turn()
-
-        test_battle = Battle(player1.team, player2.team)
-        test_battle.battle()
-
-    def test_caterpillar_order_high_attack(self):
-        cp = Pet("caterpillar")
-        cp.level = 3
-        cp._attack = 5  # 1 more than dolphin
-        cp._health = 7
-        t = Team([cp, "dragon"])
-        t2 = Team(["dolphin", "dragon"])
-        b = Battle(t, t2)
-        r = b.battle()
-        # print(b.battle_history) # caterpillar evolves first, dolphin snipes butterfly, 1v2 loss
-        self.assertEqual(r, 1)
-
-    def test_caterpillar_order_low_attack(self):
-        cp = Pet("caterpillar")
-        cp.level = 3
-        cp._attack = 1
-        cp._health = 7
-        t = Team([cp, "dragon"])
-        t2 = Team(["dolphin", "dragon"])
-        b = Battle(t, t2)
-        r = b.battle()
-        # print(b.battle_history) # dolphin hits caterpillar, caterpillar evolves, copies dragon, win
-        self.assertEqual(r, 0)
-
-    def test_dodo(self):
-        dodo = Pet("dodo")
-        dodo.level = 3
-        dodo._attack = 10
-        team1 = Team([Pet("leopard"), dodo])
-
-        fish = Pet("fish")
-        fish._attack = 5
-        fish._health = 20
-        team2 = Team([fish])
-
-        test_battle = Battle(team1, team2)
-        result = test_battle.battle()
-
-        # dodo adds enough attack for leopard to kill fish
-        self.assertEqual(result, 0)
-
-    def test_ant_in_battle(self):
-        team1 = Team([Pet("ant"), Pet("fish")])
-        team2 = Team([Pet("camel")])
-
-        test_battle = Battle(team1, team2)
-        result = test_battle.battle()
-        self.assertEqual(result, 0)
-
-    def test_horse_in_battle(self):
-        team1 = Team([Pet("cricket"), Pet("horse")])
-        team2 = Team([Pet("camel")])
-
-        test_battle = Battle(team1, team2)
-        result = test_battle.battle()
-        self.assertEqual(test_battle.t0.empty, [0, 1, 2, 3, 4])
-        self.assertEqual(test_battle.t1[0].health, 1)
-
-    def test_horse_with_bee_in_battle(self):
-        cricket = Pet("cricket")
-        cricket.status = "status-honey-bee"
-        team1 = Team([cricket, Pet("horse")])
-        fish = Pet("fish")
-        fish._health = 5
-        team2 = Team([fish, Pet("beaver")])
-
-        test_battle = Battle(team1, team2)
-        result = test_battle.battle()
-        self.assertEqual(result, 2)
-
-    def test_mosquito_in_battle(self):
-        team1 = Team([Pet("mosquito")])
-        team2 = Team([Pet("pig")])
-
-        test_battle = Battle(team1, team2)
-        result = test_battle.battle()
-        self.assertEqual(result, 0)
-
-    def test_blowfish_pingpong(self):
-        # they hit eachother once, rest of the battle is constant hurt triggers until they both faint
-        b1 = Pet("blowfish")
-        b1._attack = 1
-        b1._health = 50
-
-        b2 = Pet("blowfish")
-        b2._attack = 1
-        b2._health = 50
-
-        b = Battle(Team([b1]), Team([b2]))
-        r = b.battle()
-        self.assertTrue(
-            "attack 1" not in b.battle_history
-        )  # they attack eachother, then keep using hurt_triggers until one of them dies, should never reach a 2nd attack phase
-
-    def test_elephant_blowfish(self):
-        # blowfish snipes first fish in 'before-attack' phase of elephant, leaving elephant without a target to attack normally
-        # then snipes second fish in next turn's 'before attack'
-        state = np.random.RandomState(seed=1).get_state()
-
-        e1 = Pet("elephant")
-        e1._attack = 1
-        e1._health = 5
-
-        b1 = Pet("blowfish", seed_state=state)
-        b1._attack = 1
-        b1._health = 5
-
-        f1 = Pet("fish")
-        f1._attack = 50
-        f1._health = 1
-        f1.status = "status-splash-attack"
-
-        f2 = Pet("fish")
-        f2._attack = 50
-        f2._health = 1
-        f2.status = "status-splash-attack"
-
-        b = Battle(Team([e1, b1]), Team([f1, f2]))
-        r = b.battle()
-        self.assertEqual(r, 0)
-
-    def test_hedgehog_blowfish_camel_hurt_team(self):
-        # standard hedgehog blowfish camel teams facing off against eachother
-        # lots of hurt triggers going off within one turn
-        state1 = np.random.RandomState(seed=2).get_state()
-        state2 = np.random.RandomState(seed=2).get_state()
-
-        bf1 = Pet("blowfish", seed_state=state1)
-        bf1._attack = 20
-        bf1._health = 20
-        bf1.level = 3
-        bf1.status = "status-garlic-armor"
-
-        c1 = Pet("camel")
-        c1._attack = 20
-        c1._health = 20
-        c1.level = 2
-        c1.status = "status-garlic-armor"
-
-        hh1 = Pet("hedgehog")
-        hh2 = Pet("hedgehog")
-
-        bf2 = Pet("blowfish", seed_state=state2)
-        bf2._attack = 20
-        bf2._health = 20
-        bf2.level = 3
-        bf2.status = "status-garlic-armor"
-
-        c2 = Pet("camel")
-        c2._attack = 20
-        c2._health = 20
-        c2.level = 2
-        c2.status = "status-garlic-armor"
-
-        hh3 = Pet("hedgehog")
-        hh4 = Pet("hedgehog")
-
-        b = Battle(Team([hh1, hh2, c1, bf1]), Team([hh3, hh4, c2, bf2]))
-        r = b.battle()
-        self.assertEqual(r, 2)
-
-    def test_hedgehog_vs_honey(self):
-        hh1 = Pet("hedgehog")
-        hh2 = Pet("hedgehog")
-        hh3 = Pet("hedgehog")
-        hh4 = Pet("hedgehog")
-        hh5 = Pet("hedgehog")
-        f1 = Pet("fish")
-        f1.status = "status-honey-bee"
-
-        b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
-        r = b.battle()
-        # ability triggers always go before status triggers
-        # fish wins since honey bee spawns at the end of the turn, after all faint triggers are completed
-        self.assertEqual(r, 1)
-
-    def test_hedgehog_vs_mushroom(self):
-        hh1 = Pet("hedgehog")
-        hh2 = Pet("hedgehog")
-        hh3 = Pet("hedgehog")
-        hh4 = Pet("hedgehog")
-        hh5 = Pet("hedgehog")
-        f1 = Pet("fish")
-        f1.status = "status-extra-life"
-
-        b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
-        r = b.battle()
-        # ability triggers always go before status triggers
-        # fish wins since mushroom spawns at the end of the turn, after all faint triggers are completed
-        self.assertEqual(r, 1)
-
-    def test_mushroom_scorpion(self):
-        scorpion = Pet("scorpion")
-        scorpion.status = "status-extra-life"
-        b = Battle(Team([scorpion]), Team(["dragon"]))
-        r = b.battle()
-        self.assertEqual(r, 2)  # draw since scorpion respawns with poison.
-
-    def test_badger_draws(self):
-        # normal 1v1
-        b1 = Pet("badger")
-        b2 = Pet("badger")
-        b = Battle(Team([b1]), Team([b2]))
-        r = b.battle()
-        self.assertEqual(r, 2)
-
-        # 1 survives, enemy ability kills
-        b1 = Pet("badger")
-        b1._health = 6
-        b2 = Pet("badger")
-        b = Battle(Team([b1]), Team([b2]))
-        r = b.battle()
-        self.assertEqual(r, 2)
-
-        # normal honey 1v1
-        hb1 = Pet("badger")
-        hb1.status = "status-honey-bee"
-        hb2 = Pet("badger")
-        hb2.status = "status-honey-bee"
-        b = Battle(Team([hb1]), Team([hb2]))
-        r = b.battle()
-        self.assertEqual(r, 2)
-
-        # 1 survives, enemy ability kills
-        hb1 = Pet("badger")
-        hb1.status = "status-honey-bee"
-        hb1._health = 6
-        hb2 = Pet("badger")
-        hb2.status = "status-honey-bee"
-        b = Battle(Team([hb1]), Team([hb2]))
-        r = b.battle()
-        self.assertEqual(r, 2)
-
-        # 1 survives, enemey ability kills, even with less attack priority should NOT be able to hit bee with ability
-        hb1 = Pet("badger")
-        hb1.status = "status-honey-bee"
-        hb1._attack = 4
-        hb1._health = 6
-        hb2 = Pet("badger")
-        hb2.status = "status-honey-bee"
-        b = Battle(Team([hb1]), Team([hb2]))
-        r = b.battle()
-        self.assertEqual(r, 2)
-
-        # badger with less attack can kill zombie-cricket
-        b1 = Pet("badger")
-        c1 = Pet("cricket")
-        c1._attack = 6
-        b = Battle(Team([b1]), Team([c1]))
-        r = b.battle()
-        self.assertEqual(r, 2)
-
-        # badger with higher priority hits nothing with ability, zombie-cricket spanws and bee spawns
-        hb1 = Pet("badger")
-        hb1.status = "status-honey-bee"
-        c1 = Pet("cricket")
-        c1._attack = 4
-        b = Battle(Team([hb1]), Team([c1]))
-        r = b.battle()
-        self.assertEqual(r, 2)
-
-    def test_badger_wins(self):
-        # bee win
-        hb1 = Pet("badger")
-        hb1.status = "status-honey-bee"
-        b2 = Pet("badger")
-        b = Battle(Team([hb1]), Team([b2]))
-        r = b.battle()
-        self.assertEqual(r, 0)
-
-        # badger with higher priority hits nothing with ability, zombie-cricket spanws and wins
-        c1 = Pet("cricket")
-        c1._attack = 4
-        b1 = Pet("badger")
-        b = Battle(Team([c1]), Team([b1]))
-        r = b.battle()
-        self.assertEqual(r, 0)
-
-        # badger with less attack can kill zombie-cricket, then bee spawns
-        hb1 = Pet("badger")
-        hb1.status = "status-honey-bee"
-        c1 = Pet("cricket")
-        c1._attack = 6
-        b = Battle(Team([hb1]), Team([c1]))
-        r = b.battle()
-        self.assertEqual(r, 0)
-
-    def test_rat_summons_at_front(self):
-        team1 = Team(["rat", "blowfish"])
-        fish = Pet("fish")
-        fish._attack = 5
-        big_attack_pet = Pet("beaver")
-        big_attack_pet._attack = 50
-        team2 = Team([fish, big_attack_pet])
-
-        test_battle = Battle(team1, team2)
-        result = test_battle.battle()
-        self.assertEqual(result, 0)
-
-    def test_badger(self):
-        seed_state = np.random.RandomState(seed=1).get_state()
-        badger_frac = [None, 0.5, 1.0, 1.5]
-        ### Testing that badger damage is correct across entire relevant range
-        for l in range(1, 4):
-            for i in range(1, 50):
-                t0 = Team(["badger", "fish", "fish"], seed_state=seed_state)
-                t0[0].obj.level = l
-                t0[0].obj._attack = i
-                t0[0].obj._health = 1
-                t1 = Team(["mosquito", "fish"], seed_state=seed_state)
-                t0[0].obj.hurt(1)
-                activated, targets, _ = t0[0].obj.faint_trigger(
-                    t0[0].obj, [0, 0], oteam=t1
-                )
-
-                badger_damage = max(int(i * badger_frac[l]), 1)
-                self.assertTrue(activated)
-                self.assertEqual(targets, [t1[0].obj, t0[1].obj])
-                self.assertEqual(t0[1].obj.health, 2 - badger_damage)
-                self.assertEqual(t1[0].obj.health, 2 - badger_damage)
-                self.assertEqual(t0[2].obj.health, 2)
-                self.assertEqual(t1[1].obj.health, 2)
-
-        ### Testing badger damage is correct for different positions
-        t0 = Team(["fish", "badger", "fish"], seed_state=seed_state)
-        t0[1].obj.level = 2
-        t0[1].obj._attack = 4
-        t0[1].obj._health = 1
-        t1 = Team(["mosquito", "fish"], seed_state=seed_state)
-        t0[1].obj.hurt(1)
-        activated, targets, _ = t0[1].obj.faint_trigger(t0[1].obj, [0, 1], oteam=t1)
-        badger_damage = 4
-        self.assertEqual(targets, [t0[0].obj, t0[2].obj])
-        self.assertEqual(t0[0].obj.health, 2 - 4)
-        self.assertEqual(t0[2].obj.health, 2 - 4)
-
-        t0 = Team(["fish", "fish", "badger"], seed_state=seed_state)
-        t0[2].obj.level = 2
-        t0[2].obj._attack = 4
-        t0[2].obj._health = 1
-        t1 = Team(["mosquito", "fish"], seed_state=seed_state)
-        t0[2].obj.hurt(1)
-        activated, targets, _ = t0[2].obj.faint_trigger(t0[2].obj, [0, 2], oteam=t1)
-        badger_damage = 4
-        self.assertEqual(targets, [t0[1].obj])
-        self.assertEqual(t0[1].obj.health, 2 - 4)
-
-    def test_peacock(self):
-        ### Check that peacock attack is correct after battle
-
-        ### Check peacock attack after elephant for all three levels
-
-        ### Check peacock after headgehog on both teams
-
-        ### Implement later with others
-        pass
+        t1[3].pet.level = 3
+        priority = battle.calculate_pet_priority(seed=0)
+        self.assertEqual(priority, ref_priority)
+
+
+# class TestBattles(unittest.TestCase):
+#     def test_multi_hurt(self):
+#         seed_state = np.random.RandomState(seed=3).get_state()
+#         t0 = Team(["badger", "camel", "fish"], seed_state=seed_state)
+#         t0[0].pet._health = 1
+#         t0[0].pet._attack = 1
+#         t1 = Team(["cricket", "mosquito", "tiger"], seed_state=seed_state)
+
+#         b = Battle(t0, t1)
+#         b.battle()
+
+#         ### For this seed, enemy mosquito hits camel and badger
+#         ### Camel will activate for mosquito, badger, cricket, zombie cricket
+#         camel_buff = 2 * 4
+#         tiger_attack = t1[2].obj.attack
+#         self.assertEqual(len(b.t1.filled), 0)
+#         self.assertEqual(b.t0[0].health, 2 + camel_buff - tiger_attack)
+#         self.assertEqual(b.t0[0].attack, 2 + camel_buff)
+
+#     def test_multi_faint(self):
+#         t0 = Team(["badger", "camel", "fish"])
+#         t0[0].pet._health = 1
+#         t0[0].pet._attack = 6
+#         t0[0].pet.level = 2
+#         t1 = Team(["cricket", "horse", "mosquito", "tiger"])
+
+#         b = Battle(t0, t1)
+#         b.attack()
+
+#         ### Cricket will kill badger, badger faint should kill camel and horse
+
+#     def test_before_and_after_attack(self):
+#         t0 = Team(["elephant", "snake", "dragon", "fish"])
+#         t1 = Team(["cricket", "horse", "fly", "tiger"])
+#         t0[2]._health = 50
+
+#         b = Battle(t0, t1)
+#         b.battle()
+#         t0 = Team(["elephant", "snake", "dragon", "fish"])
+#         t1 = Team(["cricket", "horse", "fly", "tiger"])
+#         t0[2]._health = 50
+
+#         b = Battle(t0, t1)
+#         b.battle()
+
+#     def test_rhino_test(self):
+#         t0 = Team(["horse", "horse", "horse", "horse"])
+#         t1 = Team(["rhino", "tiger"])
+
+#         b = Battle(t0, t1)
+#         b.battle()
+
+#     def test_hippo_test(self):
+#         t0 = Team(["horse", "horse", "horse", "horse"])
+#         t1 = Team(["hippo", "tiger"])
+
+#         b = Battle(t0, t1)
+#         b.battle()
+
+#     def test_whale_without_swallow_target(self):
+#         team1 = Team([Pet("fish")])
+#         team2 = Team([Pet("whale"), Pet("hedgehog"), Pet("fish"), Pet("rabbit")])
+
+#         test_battle = Battle(team1, team2)
+#         test_battle.battle()
+
+#     def test_cat_battle(self):
+#         team1 = Team([Pet("fish")])
+#         team2 = Team([Pet("cat")])
+
+#         test_battle = Battle(team1, team2)
+#         test_battle.battle()
+
+#     def test_multiple_hedgehog(self):
+#         team1 = Team([Pet("fish"), Pet("hedgehog")])
+#         team2 = Team([Pet("elephant"), Pet("hedgehog")])
+
+#         test_battle = Battle(team1, team2)
+#         test_battle.battle()
+
+#     def test_whale_parrot_swallow(self):
+#         team1 = Team([Pet("whale"), Pet("parrot")])
+#         team2 = Team([Pet("fish"), "dragon"])
+
+#         player1 = Player(team=team1)
+#         player2 = Player(team=team2)
+
+#         player1.end_turn()
+#         player2.end_turn()
+
+#         test_battle = Battle(player1.team, player2.team)
+#         test_battle.battle()
+
+#     def test_caterpillar_order_high_attack(self):
+#         cp = Pet("caterpillar")
+#         cp.level = 3
+#         cp._attack = 5  # 1 more than dolphin
+#         cp._health = 7
+#         t = Team([cp, "dragon"])
+#         t2 = Team(["dolphin", "dragon"])
+#         b = Battle(t, t2)
+#         r = b.battle()
+#         # print(b.battle_history) # caterpillar evolves first, dolphin snipes butterfly, 1v2 loss
+#         self.assertEqual(r, 1)
+
+#     def test_caterpillar_order_low_attack(self):
+#         cp = Pet("caterpillar")
+#         cp.level = 3
+#         cp._attack = 1
+#         cp._health = 7
+#         t = Team([cp, "dragon"])
+#         t2 = Team(["dolphin", "dragon"])
+#         b = Battle(t, t2)
+#         r = b.battle()
+#         # print(b.battle_history) # dolphin hits caterpillar, caterpillar evolves, copies dragon, win
+#         self.assertEqual(r, 0)
+
+#     def test_dodo(self):
+#         dodo = Pet("dodo")
+#         dodo.level = 3
+#         dodo._attack = 10
+#         team1 = Team([Pet("leopard"), dodo])
+
+#         fish = Pet("fish")
+#         fish._attack = 5
+#         fish._health = 20
+#         team2 = Team([fish])
+
+#         test_battle = Battle(team1, team2)
+#         result = test_battle.battle()
+
+#         # dodo adds enough attack for leopard to kill fish
+#         self.assertEqual(result, 0)
+
+#     def test_ant_in_battle(self):
+#         team1 = Team([Pet("ant"), Pet("fish")])
+#         team2 = Team([Pet("camel")])
+
+#         test_battle = Battle(team1, team2)
+#         result = test_battle.battle()
+#         self.assertEqual(result, 0)
+
+#     def test_horse_in_battle(self):
+#         team1 = Team([Pet("cricket"), Pet("horse")])
+#         team2 = Team([Pet("camel")])
+
+#         test_battle = Battle(team1, team2)
+#         result = test_battle.battle()
+#         self.assertEqual(test_battle.t0.empty, [0, 1, 2, 3, 4])
+#         self.assertEqual(test_battle.t1[0].health, 1)
+
+#     def test_horse_with_bee_in_battle(self):
+#         cricket = Pet("cricket")
+#         cricket.status = "status-honey-bee"
+#         team1 = Team([cricket, Pet("horse")])
+#         fish = Pet("fish")
+#         fish._health = 5
+#         team2 = Team([fish, Pet("beaver")])
+
+#         test_battle = Battle(team1, team2)
+#         result = test_battle.battle()
+#         self.assertEqual(result, 2)
+
+#     def test_mosquito_in_battle(self):
+#         team1 = Team([Pet("mosquito")])
+#         team2 = Team([Pet("pig")])
+
+#         test_battle = Battle(team1, team2)
+#         result = test_battle.battle()
+#         self.assertEqual(result, 0)
+
+#     def test_blowfish_pingpong(self):
+#         # they hit eachother once, rest of the battle is constant hurt triggers until they both faint
+#         b1 = Pet("blowfish")
+#         b1._attack = 1
+#         b1._health = 50
+
+#         b2 = Pet("blowfish")
+#         b2._attack = 1
+#         b2._health = 50
+
+#         b = Battle(Team([b1]), Team([b2]))
+#         r = b.battle()
+#         self.assertTrue(
+#             "attack 1" not in b.battle_history
+#         )  # they attack eachother, then keep using hurt_triggers until one of them dies, should never reach a 2nd attack phase
+
+#     def test_elephant_blowfish(self):
+#         # blowfish snipes first fish in 'before-attack' phase of elephant, leaving elephant without a target to attack normally
+#         # then snipes second fish in next turn's 'before attack'
+#         state = np.random.RandomState(seed=1).get_state()
+
+#         e1 = Pet("elephant")
+#         e1._attack = 1
+#         e1._health = 5
+
+#         b1 = Pet("blowfish", seed_state=state)
+#         b1._attack = 1
+#         b1._health = 5
+
+#         f1 = Pet("fish")
+#         f1._attack = 50
+#         f1._health = 1
+#         f1.status = "status-splash-attack"
+
+#         f2 = Pet("fish")
+#         f2._attack = 50
+#         f2._health = 1
+#         f2.status = "status-splash-attack"
+
+#         b = Battle(Team([e1, b1]), Team([f1, f2]))
+#         r = b.battle()
+#         self.assertEqual(r, 0)
+
+#     def test_hedgehog_blowfish_camel_hurt_team(self):
+#         # standard hedgehog blowfish camel teams facing off against eachother
+#         # lots of hurt triggers going off within one turn
+#         state1 = np.random.RandomState(seed=2).get_state()
+#         state2 = np.random.RandomState(seed=2).get_state()
+
+#         bf1 = Pet("blowfish", seed_state=state1)
+#         bf1._attack = 20
+#         bf1._health = 20
+#         bf1.level = 3
+#         bf1.status = "status-garlic-armor"
+
+#         c1 = Pet("camel")
+#         c1._attack = 20
+#         c1._health = 20
+#         c1.level = 2
+#         c1.status = "status-garlic-armor"
+
+#         hh1 = Pet("hedgehog")
+#         hh2 = Pet("hedgehog")
+
+#         bf2 = Pet("blowfish", seed_state=state2)
+#         bf2._attack = 20
+#         bf2._health = 20
+#         bf2.level = 3
+#         bf2.status = "status-garlic-armor"
+
+#         c2 = Pet("camel")
+#         c2._attack = 20
+#         c2._health = 20
+#         c2.level = 2
+#         c2.status = "status-garlic-armor"
+
+#         hh3 = Pet("hedgehog")
+#         hh4 = Pet("hedgehog")
+
+#         b = Battle(Team([hh1, hh2, c1, bf1]), Team([hh3, hh4, c2, bf2]))
+#         r = b.battle()
+#         self.assertEqual(r, 2)
+
+#     def test_hedgehog_vs_honey(self):
+#         hh1 = Pet("hedgehog")
+#         hh2 = Pet("hedgehog")
+#         hh3 = Pet("hedgehog")
+#         hh4 = Pet("hedgehog")
+#         hh5 = Pet("hedgehog")
+#         f1 = Pet("fish")
+#         f1.status = "status-honey-bee"
+
+#         b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
+#         r = b.battle()
+#         # ability triggers always go before status triggers
+#         # fish wins since honey bee spawns at the end of the turn, after all faint triggers are completed
+#         self.assertEqual(r, 1)
+
+#     def test_hedgehog_vs_mushroom(self):
+#         hh1 = Pet("hedgehog")
+#         hh2 = Pet("hedgehog")
+#         hh3 = Pet("hedgehog")
+#         hh4 = Pet("hedgehog")
+#         hh5 = Pet("hedgehog")
+#         f1 = Pet("fish")
+#         f1.status = "status-extra-life"
+
+#         b = Battle(Team([hh1, hh2, hh3, hh4, hh5]), Team([f1]))
+#         r = b.battle()
+#         # ability triggers always go before status triggers
+#         # fish wins since mushroom spawns at the end of the turn, after all faint triggers are completed
+#         self.assertEqual(r, 1)
+
+#     def test_mushroom_scorpion(self):
+#         scorpion = Pet("scorpion")
+#         scorpion.status = "status-extra-life"
+#         b = Battle(Team([scorpion]), Team(["dragon"]))
+#         r = b.battle()
+#         self.assertEqual(r, 2)  # draw since scorpion respawns with poison.
+
+#     def test_badger_draws(self):
+#         # normal 1v1
+#         b1 = Pet("badger")
+#         b2 = Pet("badger")
+#         b = Battle(Team([b1]), Team([b2]))
+#         r = b.battle()
+#         self.assertEqual(r, 2)
+
+#         # 1 survives, enemy ability kills
+#         b1 = Pet("badger")
+#         b1._health = 6
+#         b2 = Pet("badger")
+#         b = Battle(Team([b1]), Team([b2]))
+#         r = b.battle()
+#         self.assertEqual(r, 2)
+
+#         # normal honey 1v1
+#         hb1 = Pet("badger")
+#         hb1.status = "status-honey-bee"
+#         hb2 = Pet("badger")
+#         hb2.status = "status-honey-bee"
+#         b = Battle(Team([hb1]), Team([hb2]))
+#         r = b.battle()
+#         self.assertEqual(r, 2)
+
+#         # 1 survives, enemy ability kills
+#         hb1 = Pet("badger")
+#         hb1.status = "status-honey-bee"
+#         hb1._health = 6
+#         hb2 = Pet("badger")
+#         hb2.status = "status-honey-bee"
+#         b = Battle(Team([hb1]), Team([hb2]))
+#         r = b.battle()
+#         self.assertEqual(r, 2)
+
+#         # 1 survives, enemey ability kills, even with less attack priority should NOT be able to hit bee with ability
+#         hb1 = Pet("badger")
+#         hb1.status = "status-honey-bee"
+#         hb1._attack = 4
+#         hb1._health = 6
+#         hb2 = Pet("badger")
+#         hb2.status = "status-honey-bee"
+#         b = Battle(Team([hb1]), Team([hb2]))
+#         r = b.battle()
+#         self.assertEqual(r, 2)
+
+#         # badger with less attack can kill zombie-cricket
+#         b1 = Pet("badger")
+#         c1 = Pet("cricket")
+#         c1._attack = 6
+#         b = Battle(Team([b1]), Team([c1]))
+#         r = b.battle()
+#         self.assertEqual(r, 2)
+
+#         # badger with higher priority hits nothing with ability, zombie-cricket spanws and bee spawns
+#         hb1 = Pet("badger")
+#         hb1.status = "status-honey-bee"
+#         c1 = Pet("cricket")
+#         c1._attack = 4
+#         b = Battle(Team([hb1]), Team([c1]))
+#         r = b.battle()
+#         self.assertEqual(r, 2)
+
+#     def test_badger_wins(self):
+#         # bee win
+#         hb1 = Pet("badger")
+#         hb1.status = "status-honey-bee"
+#         b2 = Pet("badger")
+#         b = Battle(Team([hb1]), Team([b2]))
+#         r = b.battle()
+#         self.assertEqual(r, 0)
+
+#         # badger with higher priority hits nothing with ability, zombie-cricket spanws and wins
+#         c1 = Pet("cricket")
+#         c1._attack = 4
+#         b1 = Pet("badger")
+#         b = Battle(Team([c1]), Team([b1]))
+#         r = b.battle()
+#         self.assertEqual(r, 0)
+
+#         # badger with less attack can kill zombie-cricket, then bee spawns
+#         hb1 = Pet("badger")
+#         hb1.status = "status-honey-bee"
+#         c1 = Pet("cricket")
+#         c1._attack = 6
+#         b = Battle(Team([hb1]), Team([c1]))
+#         r = b.battle()
+#         self.assertEqual(r, 0)
+
+#     def test_rat_summons_at_front(self):
+#         team1 = Team(["rat", "blowfish"])
+#         fish = Pet("fish")
+#         fish._attack = 5
+#         big_attack_pet = Pet("beaver")
+#         big_attack_pet._attack = 50
+#         team2 = Team([fish, big_attack_pet])
+
+#         test_battle = Battle(team1, team2)
+#         result = test_battle.battle()
+#         self.assertEqual(result, 0)
+
+#     def test_badger(self):
+#         seed_state = np.random.RandomState(seed=1).get_state()
+#         badger_frac = [None, 0.5, 1.0, 1.5]
+#         ### Testing that badger damage is correct across entire relevant range
+#         for l in range(1, 4):
+#             for i in range(1, 50):
+#                 t0 = Team(["badger", "fish", "fish"], seed_state=seed_state)
+#                 t0[0].obj.level = l
+#                 t0[0].obj._attack = i
+#                 t0[0].obj._health = 1
+#                 t1 = Team(["mosquito", "fish"], seed_state=seed_state)
+#                 t0[0].obj.hurt(1)
+#                 activated, targets, _ = t0[0].obj.faint_trigger(
+#                     t0[0].obj, [0, 0], oteam=t1
+#                 )
+
+#                 badger_damage = max(int(i * badger_frac[l]), 1)
+#                 self.assertTrue(activated)
+#                 self.assertEqual(targets, [t1[0].obj, t0[1].obj])
+#                 self.assertEqual(t0[1].obj.health, 2 - badger_damage)
+#                 self.assertEqual(t1[0].obj.health, 2 - badger_damage)
+#                 self.assertEqual(t0[2].obj.health, 2)
+#                 self.assertEqual(t1[1].obj.health, 2)
+
+#         ### Testing badger damage is correct for different positions
+#         t0 = Team(["fish", "badger", "fish"], seed_state=seed_state)
+#         t0[1].obj.level = 2
+#         t0[1].obj._attack = 4
+#         t0[1].obj._health = 1
+#         t1 = Team(["mosquito", "fish"], seed_state=seed_state)
+#         t0[1].obj.hurt(1)
+#         activated, targets, _ = t0[1].obj.faint_trigger(t0[1].obj, [0, 1], oteam=t1)
+#         badger_damage = 4
+#         self.assertEqual(targets, [t0[0].obj, t0[2].obj])
+#         self.assertEqual(t0[0].obj.health, 2 - 4)
+#         self.assertEqual(t0[2].obj.health, 2 - 4)
+
+#         t0 = Team(["fish", "fish", "badger"], seed_state=seed_state)
+#         t0[2].obj.level = 2
+#         t0[2].obj._attack = 4
+#         t0[2].obj._health = 1
+#         t1 = Team(["mosquito", "fish"], seed_state=seed_state)
+#         t0[2].obj.hurt(1)
+#         activated, targets, _ = t0[2].obj.faint_trigger(t0[2].obj, [0, 2], oteam=t1)
+#         badger_damage = 4
+#         self.assertEqual(targets, [t0[1].obj])
+#         self.assertEqual(t0[1].obj.health, 2 - 4)
+
+#     def test_peacock(self):
+#         ### Check that peacock attack is correct after battle
+
+#         ### Check peacock attack after elephant for all three levels
+
+#         ### Check peacock after headgehog on both teams
+
+#         ### Implement later with others
+#         pass

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -1,4 +1,3 @@
-#%%
 import unittest
 
 import numpy as np
@@ -7,6 +6,67 @@ from sapai import *
 from sapai.battle import Battle
 from sapai.graph import graph_battle
 from sapai.compress import *
+
+
+class PetPriorityTestCase(unittest.TestCase):
+    def test_attack_priority(self):
+        """Tests attack priority determined by attack (no draws)"""
+        t0 = Team(["sloth", "sloth"])
+        t0[0].pet._attack = 1
+        t0[1].pet._attack = 3
+        t1 = Team(["sloth"])
+        t1[0].pet._attack = 2
+        result = Battle(t0, t1).calculate_pet_priority()
+        self.assertEqual(result, [(0, 1), (1, 0), (0, 0)])
+
+        t0 = Team(["sloth", "sloth"])
+        t0[0].pet._attack = 3
+        t0[1].pet._attack = 2
+        t1 = Team(["sloth"])
+        t1[0].pet._attack = 1
+        result = Battle(t0, t1).calculate_pet_priority()
+        self.assertEqual(result, [(0, 0), (0, 1), (1, 0)])
+
+        # Health or level has no priority over attack
+        t0 = Team(["sloth", "sloth"])
+        t0[0].pet._attack = 1
+        t0[0].pet._health = 50
+        t0[0].pet.level = 3
+        t0[1].pet._attack = 2
+        t1 = Team(["sloth", "sloth"])
+        t1[0].pet._attack = 3
+        t1[1].pet._attack = 4
+        result = Battle(t0, t1).calculate_pet_priority()
+        self.assertEqual(result, [(1, 1), (1, 0), (0, 1), (0, 0)])
+
+    def test_health_priority(self):
+        """Tests priority determined by health (if attack is drawn)"""
+        t0 = Team(["sloth", "sloth"])
+        t0[0].pet._health = 1
+        t0[1].pet._health = 3
+        t1 = Team(["sloth"])
+        t1[0].pet._health = 2
+        result = Battle(t0, t1).calculate_pet_priority()
+        self.assertEqual(result, [(0, 1), (1, 0), (0, 0)])
+
+        t0 = Team(["sloth", "sloth"])
+        t0[0].pet._health = 3
+        t0[1].pet._health = 2
+        t1 = Team(["sloth"])
+        t1[0].pet._health = 1
+        result = Battle(t0, t1).calculate_pet_priority()
+        self.assertEqual(result, [(0, 0), (0, 1), (1, 0)])
+
+        # level has no priority over health
+        t0 = Team(["sloth", "sloth"])
+        t0[0].pet._health = 1
+        t0[0].pet.level = 3
+        t0[1].pet._health = 2
+        t1 = Team(["sloth", "sloth"])
+        t1[0].pet._health = 3
+        t1[1].pet._health = 4
+        result = Battle(t0, t1).calculate_pet_priority()
+        self.assertEqual(result, [(1, 1), (1, 0), (0, 1), (0, 0)])
 
 
 class TestBattles(unittest.TestCase):
@@ -458,6 +518,3 @@ class TestBattles(unittest.TestCase):
 
         ### Implement later with others
         pass
-
-
-# %%


### PR DESCRIPTION
Refactor update_pet_priority into calculate_pet_priority and rewrite to no longer prioritise health (#89)

- Added tests for calculate_pet_priority
- Added seed to calculate_pet_priority
- calculate_pet_priority is no longer a static method
- Added various type annotations


The calculate_pet_priority seed uses the [new numpy random generators](https://numpy.org/devdocs/reference/random/new-or-different.html) which should improve performance. 
Might be worth checking if the performance increase gets it anywhere close to `MockRandomState`'s performance.