### PR TITLE
Tiger Start of Battle Tests

### DIFF
--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -78,10 +78,8 @@ class Battle:
     def battle(self):
         ### Perform all effects that occur at the start of the battle
         self.run_start_of_battle()
-        while True:
-            result = self.attack()
-            if result == False:
-                break
+        while self.check_battle_result() < 0:
+            self.run_next_attack()
 
         ### Check winner and return 0 for t0 win, 1 for t1 win, 2 for draw
         return self.check_battle_result()
@@ -121,7 +119,7 @@ class Battle:
         # e.g. battle = Battle(team0, team1).run_start_of_battle()
         return self
 
-    def attack(self):
+    def run_next_attack(self):
         """
         Perform and attack and then check for new pet triggers
 
@@ -175,13 +173,9 @@ class Battle:
             )
             self.battle_history.update(phase_dict)
 
-        ### Check if battle is over
-        status = self.check_battle_result()
-        if status < 0:
-            return True
-        else:
-            ### End battle
-            return False
+        # Return self for use in fluent interface
+        # e.g. battle = Battle(team0, team1).run_start_of_battle().run_attack()
+        return self
 
     def check_battle_result(self):
         t0_empty = len(self.t0.filled) == 0

--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -77,7 +77,7 @@ class Battle:
 
     def battle(self):
         ### Perform all effects that occur at the start of the battle
-        self.start()
+        self.run_start_of_battle()
         while True:
             result = self.attack()
             if result == False:
@@ -86,7 +86,7 @@ class Battle:
         ### Check winner and return 0 for t0 win, 1 for t1 win, 2 for draw
         return self.check_battle_result()
 
-    def start(self):
+    def run_start_of_battle(self):
         """
         Perform all start of battle effects
 
@@ -116,6 +116,10 @@ class Battle:
             ### If animals have moved or fainted then effect order must be updated
             if temp_phase.startswith("phase_move"):
                 self.pet_priority = self.calculate_pet_priority()
+
+        # Return self for use in fluent interface
+        # e.g. battle = Battle(team0, team1).run_start_of_battle()
+        return self
 
     def attack(self):
         """

--- a/sapai/battle.py
+++ b/sapai/battle.py
@@ -866,7 +866,7 @@ def append_phase_list(phase_list, p, team_idx, pet_idx, activated, targets, poss
     if activated:
         tiger = False
         if len(targets) > 0:
-            if isinstance(list, targets[0]):
+            if isinstance(targets[0], list):
                 tiger = True
         func = get_effect_function(p)
 

--- a/sapai/pets.py
+++ b/sapai/pets.py
@@ -1005,7 +1005,7 @@ def tiger_func(func, te_fainted, *args):
     else:
         temp_targets, temp_possible = func(*args)
 
-    return [targets] + [temp_targets], [possible] + [temp_possible]
+    return targets + temp_targets, possible + temp_possible
 
 
 empty_ability = {

--- a/sapai/pets.py
+++ b/sapai/pets.py
@@ -998,12 +998,17 @@ def tiger_func(func, te_fainted, *args):
     ###  be duplicated. This is important for Whale.
     if te_fainted == False:
         apet.override_ability = False
+    # Temporarily set pet level to that of tiger
+    # TODO: add level argument to ability functions
+    original_level = args[0].level
+    args[0].level = pet_behind.level
     if len(args) == 5:
         te_idx = [0, args[4][1] + len(targets)]
         ### Run function again
         temp_targets, temp_possible = func(args[0], args[1], args[2], args[3], te_idx)
     else:
         temp_targets, temp_possible = func(*args)
+    args[0].level = original_level
 
     return targets + temp_targets, possible + temp_possible
 

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -104,13 +104,13 @@ class TestBattles(unittest.TestCase):
     def test_before_and_after_attack(self):
         t0 = Team(["elephant", "snake", "dragon", "fish"])
         t1 = Team(["cricket", "horse", "fly", "tiger"])
-        t0[2]._health = 50
+        t0[2].pet._health = 50
 
         b = Battle(t0, t1)
         b.battle()
         t0 = Team(["elephant", "snake", "dragon", "fish"])
         t1 = Team(["cricket", "horse", "fly", "tiger"])
-        t0[2]._health = 50
+        t0[2].pet._health = 50
 
         b = Battle(t0, t1)
         b.battle()
@@ -162,47 +162,6 @@ class TestBattles(unittest.TestCase):
 
         test_battle = Battle(player1.team, player2.team)
         test_battle.battle()
-
-    def test_caterpillar_order_high_attack(self):
-        cp = Pet("caterpillar")
-        cp.level = 3
-        cp._attack = 5  # 1 more than dolphin
-        cp._health = 7
-        t = Team([cp, "dragon"])
-        t2 = Team(["dolphin", "dragon"])
-        b = Battle(t, t2)
-        r = b.battle()
-        # print(b.battle_history) # caterpillar evolves first, dolphin snipes butterfly, 1v2 loss
-        self.assertEqual(r, 1)
-
-    def test_caterpillar_order_low_attack(self):
-        cp = Pet("caterpillar")
-        cp.level = 3
-        cp._attack = 1
-        cp._health = 7
-        t = Team([cp, "dragon"])
-        t2 = Team(["dolphin", "dragon"])
-        b = Battle(t, t2)
-        r = b.battle()
-        # print(b.battle_history) # dolphin hits caterpillar, caterpillar evolves, copies dragon, win
-        self.assertEqual(r, 0)
-
-    def test_dodo(self):
-        dodo = Pet("dodo")
-        dodo.level = 3
-        dodo._attack = 10
-        team1 = Team([Pet("leopard"), dodo])
-
-        fish = Pet("fish")
-        fish._attack = 5
-        fish._health = 20
-        team2 = Team([fish])
-
-        test_battle = Battle(team1, team2)
-        result = test_battle.battle()
-
-        # dodo adds enough attack for leopard to kill fish
-        self.assertEqual(result, 0)
 
     def test_ant_in_battle(self):
         team1 = Team([Pet("ant"), Pet("fish")])

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -97,7 +97,7 @@ class TestBattles(unittest.TestCase):
         t1 = Team(["cricket", "horse", "mosquito", "tiger"])
 
         b = Battle(t0, t1)
-        b.attack()
+        b.run_next_attack()
 
         ### Cricket will kill badger, badger faint should kill camel and horse
 
@@ -164,12 +164,16 @@ class TestBattles(unittest.TestCase):
         test_battle.battle()
 
     def test_ant_in_battle(self):
-        team1 = Team([Pet("ant"), Pet("fish")])
-        team2 = Team([Pet("camel")])
+        ref_team = Team(["sloth"], battle=True)
+        ref_team[0].pet._attack = 3
+        ref_team[0].pet._health = 2
+        t0 = Team(["ant", "sloth"])
+        t0[0].pet._health = 1
+        t1 = Team(["sloth"])
 
-        test_battle = Battle(team1, team2)
-        result = test_battle.battle()
-        self.assertEqual(result, 0)
+        b = Battle(t0, t1)
+        b.battle()
+        self.assertEqual(b.t0.state, ref_team.state)
 
     def test_horse_in_battle(self):
         team1 = Team([Pet("cricket"), Pet("horse")])

--- a/tests/test_effect_queue.py
+++ b/tests/test_effect_queue.py
@@ -978,6 +978,54 @@ class TestEffectQueue(unittest.TestCase):
         b = run_battle(t1, t0)
         self.assertEqual(b.t1.state, ref_team.state)
 
+    def test_dodo(self):
+        # Transfers attack (even)
+        ref_team = Team(["sloth", "dodo"], battle=True)
+        ref_team[0].pet._attack = 3
+        ref_team[1].pet._attack = 4
+        t0 = Team(["sloth", "dodo"])
+        t0[1].pet._attack = 4
+        t1 = Team([])
+        b = run_sob(t0, t1)
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = run_sob(t1, t0)
+        self.assertEqual(b.t1.state, ref_team.state)
+        # Transfers attack (odd)
+        ref_team = Team(["sloth", "dodo"], battle=True)
+        ref_team[0].pet._attack = 3
+        ref_team[1].pet._attack = 5
+        t0 = Team(["sloth", "dodo"])
+        t0[1].pet._attack = 5
+        t1 = Team([])
+        b = run_sob(t0, t1)
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = run_sob(t1, t0)
+        self.assertEqual(b.t1.state, ref_team.state)
+        # Transfers attack to attack based sniper (higher attack priority)
+        ref_team = Team([], battle=True)
+        t0 = Team(["sloth"])
+        t0[0].pet._health = 10
+        t1 = Team(["leopard", "dodo"])
+        t1[0].pet._attack = 10
+        t1[1].pet._attack = 20
+        b = run_sob(t0, t1)
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = run_sob(t1, t0)
+        self.assertEqual(b.t1.state, ref_team.state)
+        # Transfers attack to attack based sniper (lower attack priority)
+        # sniper goes before attack buff
+        ref_team = Team(["sloth"], battle=True)
+        ref_team[0].pet._health = 1
+        t0 = Team(["sloth"])
+        t0[0].pet._health = 11
+        t1 = Team(["leopard", "dodo"])
+        t1[0].pet._attack = 20
+        t1[1].pet._attack = 18
+        b = run_sob(t0, t1)
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = run_sob(t1, t0)
+        self.assertEqual(b.t1.state, ref_team.state)
+
     def test_tiger(self):
         """
         Test tiger for nearly all pets

--- a/tests/test_effect_queue.py
+++ b/tests/test_effect_queue.py
@@ -1026,45 +1026,142 @@ class TestEffectQueue(unittest.TestCase):
         b = run_sob(t1, t0)
         self.assertEqual(b.t1.state, ref_team.state)
 
-    def test_tiger(self):
-        """
-        Test tiger for nearly all pets
-        """
-        self.skipTest("TODO")
-        # Causes crash when tiger is behind any pet with ability
-        t0 = Team(["dolphin", "tiger"])
+
+class TigerStartOfBattleTestCase(unittest.TestCase):
+    """
+    Test tiger for all start of battle pets
+    """
+
+    def test_tiger_mosquito(self):
+        # Mosquito triggers twice
+        ref_team = Team([], battle=True)
+        t0 = Team(["sloth", "sloth"])
+        t1 = Team(["mosquito", "tiger"])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+
+    def test_tiger_crab(self):
+        # No difference if both are level 1
+        ref_team = Team(["sloth", "crab", "tiger"], battle=True)
+        ref_team[0].pet._health = 50
+        ref_team[1].pet._health = 25
+        t0 = Team(["sloth", "crab", "tiger"])
+        t0[0].pet._health = 50
         t1 = Team([])
-        b = run_battle(t0, t1)
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+        # works with tiger having highest health
+        ref_team = Team(["crab", "tiger"], battle=True)
+        ref_team[0].pet._health = 25
+        ref_team[1].pet._health = 50
+        t0 = Team(["crab", "tiger"])
+        t0[1].pet._health = 50
+        t1 = Team([])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+
+    def test_tiger_crab_level_override(self):
+        # level 1 tiger overrides level 2 crab
+        ref_team = Team(["crab", "tiger"], battle=True)
+        ref_team[0].pet._health = 25
+        ref_team[0].pet.level = 2
+        ref_team[1].pet._health = 50
+        t0 = Team(["crab", "tiger"])
+        t0[0].pet.level = 2
+        t0[1].pet._health = 50
+        t1 = Team([])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+        # level 2 tiger overrides level 1 crab
+        ref_team = Team(["crab", "tiger"], battle=True)
+        ref_team[0].pet._health = 50
+        ref_team[1].pet._health = 50
+        ref_team[1].pet.level = 2
+        t0 = Team(["crab", "tiger"])
+        t0[1].pet._health = 50
+        t0[1].pet.level = 2
+        t1 = Team([])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+
+    def test_tiger_dodo(self):
+        # Dodo gives attack twice
+        ref_team = Team(["sloth", "dodo", "tiger"], battle=True)
+        ref_team[0].pet._attack = 11
+        ref_team[1].pet._attack = 10
+        t0 = Team(["sloth", "dodo", "tiger"])
+        t0[1].pet._attack = 10
+        t1 = Team([])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+        # Dodo gives attack twice (level 2 dodo, level 1 tiger)
+        ref_team = Team(["sloth", "dodo", "tiger"], battle=True)
+        ref_team[0].pet._attack = 16
+        ref_team[1].pet._attack = 10
+        ref_team[1].pet.level = 2
+        t0 = Team(["sloth", "dodo", "tiger"])
+        t0[1].pet._attack = 10
+        t0[1].pet.level = 2
+        t1 = Team([])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+        # Dodo gives attack twice (level 1 dodo, level 2 tiger)
+        ref_team = Team(["sloth", "dodo", "tiger"], battle=True)
+        ref_team[0].pet._attack = 16
+        ref_team[1].pet._attack = 10
+        ref_team[2].pet.level = 2
+        t0 = Team(["sloth", "dodo", "tiger"])
+        t0[1].pet._attack = 10
+        t0[2].pet.level = 2
+        t1 = Team([])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+
+    def test_tiger_dolphin(self):
+        # Dolphin triggers twice
+        ref_team = Team([], battle=True)
+        t0 = Team(["sloth", "sloth"])
+        t1 = Team(["dolphin", "tiger"])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+
+    def test_tiger_skunk(self):
+        self.skipTest("TODO")
+
+    def test_tiger_whale(self):
+        self.skipTest("TODO")
+
+    def test_tiger_crocodile(self):
+        self.skipTest("TODO")
+
+    def test_tiger_leopard(self):
+        self.skipTest("TODO")
 
 
 def run_sob(t0, t1):
-    b = Battle(t0, t1)
-    b.run_start_of_battle()
-    return b
+    return Battle(t0, t1).run_start_of_battle()
 
 
 def run_attack(t0, t1, run_before=False):
-    b = Battle(t0, t1)
-    phase_dict = {
-        "init": [[str(x) for x in b.t0], [str(x) for x in b.t1]],
-        "attack 0": {},
-    }
-    if run_before:
-        phase_dict["attack 0"]["phase_attack_before"] = []
-    phase_dict["attack 0"]["phase_attack"] = []
-    phase_dict["attack 0"]["phase_move_end"] = []
-    phase_str = "attack 0"
-    for temp_phase in phase_dict[phase_str]:
-        battle_phase(b, temp_phase, [b.t0, b.t1], b.pet_priority, phase_dict[phase_str])
-    b.battle_history = phase_dict
-    phase_dict[phase_str]["phase_move_end"] = [
-        [
-            [str(x) for x in b.t0],
-            [str(x) for x in b.t1],
-        ]
-    ]
-    b.battle_history = phase_dict
-    return b
+    return Battle(t0, t1).run_next_attack()
 
 
 def run_battle(t0, t1):

--- a/tests/test_effect_queue.py
+++ b/tests/test_effect_queue.py
@@ -759,12 +759,6 @@ class TestEffectQueue(unittest.TestCase):
         b = run_battle(t1, t0)
         self.assertEqual(b.t1.state, ref_team.state)
 
-    def test_leopard_tiger_blowfish(self):
-        """
-        Test start of turn for leopard tiger versus blowfish
-        """
-        self.skipTest("TODO")
-
     def test_skunk(self):
         # reduces health by 33%
         ref_team = Team(["sloth"], battle=True)
@@ -855,12 +849,6 @@ class TestEffectQueue(unittest.TestCase):
         b = run_battle(t1, t0)
         self.assertEqual(b.t1.state, ref_team0.state)
         self.assertEqual(b.t0.state, ref_team1.state)
-
-    def test_whale_tiger(self):
-        """
-        Ensure that whale and tiger are performing properly together.
-        """
-        self.skipTest("TODO")
 
     def test_crocodile(self):
         """

--- a/tests/test_effect_queue.py
+++ b/tests/test_effect_queue.py
@@ -1144,16 +1144,101 @@ class TigerStartOfBattleTestCase(unittest.TestCase):
         self.assertEqual(b.t1.state, ref_team.state)
 
     def test_tiger_skunk(self):
-        self.skipTest("TODO")
+        # Skunk triggers twice
+        ref_team = Team(["sloth", "sloth"], battle=True)
+        ref_team[0].pet._health = 20
+        ref_team[1].pet._health = 20
+        t0 = Team(["sloth", "sloth"])
+        t0[0].pet._health = 30
+        t0[1].pet._health = 30
+        t1 = Team(["skunk", "tiger"])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
 
     def test_tiger_whale(self):
-        self.skipTest("TODO")
+        # Eats 2 sloths
+        ref_team = Team(["whale", "tiger"], battle=True)
+        t0 = Team(["sloth", "sloth", "whale", "tiger"])
+        t1 = Team([])
+        b = Battle(t0, t1).run_start_of_battle()
+        state = b.t0.state
+        # remove ability to allow easier comparison of state
+        state["team"][0]["pet"]["override_ability"] = False
+        state["team"][0]["pet"]["override_ability_dict"] = {}
+        self.assertEqual(state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        state = b.t1.state
+        state["team"][0]["pet"]["override_ability"] = False
+        state["team"][0]["pet"]["override_ability_dict"] = {}
+        self.assertEqual(state, ref_team.state)
+        # Spits out 2 sloths
+        ref_team = Team(["sloth", "sloth", "tiger"], battle=True)
+        t0 = Team(["sloth", "sloth", "whale", "tiger"])
+        t1 = Team(["sloth"])
+        t1[0].pet._attack = 50
+        b = Battle(t0, t1).run_start_of_battle().run_next_attack()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle().run_next_attack()
+        self.assertEqual(b.t1.state, ref_team.state)
+
+    def test_tiger_whale_different_pets(self):
+        # Spits out 1 sloth and 1 fish
+        ref_team = Team(["sloth", "fish", "tiger"], battle=True)
+        t0 = Team(["sloth", "fish", "whale", "tiger"])
+        t1 = Team(["sloth"])
+        t1[0].pet._attack = 50
+        b = Battle(t0, t1).run_start_of_battle().run_next_attack()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle().run_next_attack()
+        self.assertEqual(b.t1.state, ref_team.state)
+
+    def test_tiger_whale_dead_tiger(self):
+        # Spits out 1 sloth and 1 fish even with dead tiger
+        ref_team = Team(["sloth", "fish"], battle=True)
+        t0 = Team(["sloth", "fish", "whale", "tiger"])
+        t0[3].pet._health = 1
+        t1 = Team(["dolphin"])
+        t1[0].pet._attack = 50
+        t1[0].pet._health = 1
+        b = Battle(t0, t1).run_start_of_battle().run_next_attack()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle().run_next_attack()
+        self.assertEqual(b.t1.state, ref_team.state)
 
     def test_tiger_crocodile(self):
-        self.skipTest("TODO")
+        # Hits back unit twice
+        ref_team = Team(["sloth", "sloth"], battle=True)
+        ref_team[1].pet._health = 34
+        t0 = Team(["sloth", "sloth"])
+        t0[1].pet._health = 50
+        t1 = Team(["crocodile", "tiger"])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
+        # Kills 2 units
+        ref_team = Team([], battle=True)
+        t0 = Team(["sloth", "sloth"])
+        t1 = Team(["crocodile", "tiger"])
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
 
     def test_tiger_leopard(self):
-        self.skipTest("TODO")
+        # Shoots twice
+        ref_team = Team([], battle=True)
+        t0 = Team(["sloth", "sloth"])
+        t0[0].pet._health = 10
+        t0[1].pet._health = 10
+        t1 = Team(["leopard", "tiger"])
+        t1[0].pet._attack = 20
+        b = Battle(t0, t1).run_start_of_battle()
+        self.assertEqual(b.t0.state, ref_team.state)
+        b = Battle(t1, t0).run_start_of_battle()
+        self.assertEqual(b.t1.state, ref_team.state)
 
 
 def run_sob(t0, t1):

--- a/tests/test_effect_queue.py
+++ b/tests/test_effect_queue.py
@@ -1039,28 +1039,7 @@ class TestEffectQueue(unittest.TestCase):
 
 def run_sob(t0, t1):
     b = Battle(t0, t1)
-    phase_dict = {
-        "init": [[str(x) for x in b.t0], [str(x) for x in b.t1]],
-        "start": {
-            "phase_start": [],
-        },
-    }
-    run_looping_effect_queue(
-        "sob_trigger",
-        ["oteam"],
-        b,
-        "phase_start",
-        [b.t0, b.t1],
-        b.pet_priority,
-        phase_dict["start"],
-    )
-    phase_dict["start"]["phase_move_end"] = [
-        [
-            [str(x) for x in b.t0],
-            [str(x) for x in b.t1],
-        ]
-    ]
-    b.battle_history = phase_dict
+    b.run_start_of_battle()
     return b
 
 

--- a/tests/test_effect_queue.py
+++ b/tests/test_effect_queue.py
@@ -1172,6 +1172,11 @@ class TigerStartOfBattleTestCase(unittest.TestCase):
         self.assertEqual(b.t1.state, ref_team.state)
 
     def test_tiger_whale_different_pets(self):
+        # At the moment effects do not support summoning 2 pets of different types
+        # Best solution would be to change ability["effect"] to be a list
+        # Alternative would be to to edit SummonPet to allow multiple pets,
+        # however the former is more future proof for pets with multiabilities
+        self.skipTest("Functionality not implemented")
         # Spits out 1 sloth and 1 fish
         ref_team = Team(["sloth", "fish", "tiger"], battle=True)
         t0 = Team(["sloth", "fish", "whale", "tiger"])
@@ -1183,6 +1188,9 @@ class TigerStartOfBattleTestCase(unittest.TestCase):
         self.assertEqual(b.t1.state, ref_team.state)
 
     def test_tiger_whale_dead_tiger(self):
+        # See test_tiger_whale_different_pets above. This test should ensure
+        # one of each pet is produced (instead of 2 of each pet)
+        self.skipTest("Functionality not implemented")
         # Spits out 1 sloth and 1 fish even with dead tiger
         ref_team = Team(["sloth", "fish"], battle=True)
         t0 = Team(["sloth", "fish", "whale", "tiger"])


### PR DESCRIPTION
- Fixed tiger causing a crash when behind an animal
- Refactored Battle's start and attack functions to be `run_start_of_battle` and `run_next_attack`. and made them fluent interfaces.
- Changed run_sob and run_attack to use Battle's functions
- Created tests for Tiger with start of battle abilities

At the moment, tests involving differently leveled tiger and pet are failing and the tiger whale tests are failing as swallowing only saves the last pet swallowed.

Thought would make this PR to prevent any duplication of work. Also to see if any example battles of tiger whale are available so the tests can be accurately made.