### PR TITLE
Remove redundant keras dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.6
@@ -36,7 +36,7 @@ jobs:
       max-parallel: 10
       matrix:
         python-version: [3.6]
-        os: [ubuntu-18.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
         "sapai",
     ],
     # find_packages(exclude=[]),
-    install_requires=["numpy", "keras", "torch", "graphviz"],
+    install_requires=["numpy", "torch", "graphviz"],
     data_files=[],
 )


### PR DESCRIPTION
As far as I can tell, `keras` is not used in this project. `PyTorch` seems to be used instead.

I would also avoid having both in the same project as in terms of versioning their dependencies often tend to collide.

Hence, I would remove `keras` as a requirement to avoid bloatware.