### PR TITLE
Fix cell_bg_colors validation in html_table function

### DIFF
--- a/sapai/graph.py
+++ b/sapai/graph.py
@@ -43,8 +43,8 @@ def html_table(
         for iter_idx, temp_entry in enumerate(cell_bg_colors):
             temp_length = len(temp_entry)
             temp_check_length = len(entries[iter_idx])
-            if temp_length != 0:
-                raise NotImplementedError
+            if temp_length == 0:  # Skip validation if no colors specified
+                continue
             if temp_length != temp_check_length:
                 raise Exception("Must supply one cell_bg_color for every entry")
 
@@ -99,9 +99,9 @@ def prep_pet_str(pstr):
     if len(temp_pstr_list) == 2:
         temp_stats = temp_pstr_list[1]
         replace_index = temp_stats.index("-")
-        temp_pstr_list[
-            1
-        ] = f"{temp_stats[0:replace_index]},{temp_stats[replace_index + 1 :]}"
+        temp_pstr_list[1] = (
+            f"{temp_stats[0:replace_index]},{temp_stats[replace_index + 1 :]}"
+        )
         temp_pstr = " ".join(temp_pstr_list)
     return temp_pstr
 


### PR DESCRIPTION
## Problem
The `graph_battle()` function crashes with the error:
```
Exception: Must supply one cell_bg_color for every entry
```

This occurs because the `html_table()` function's validation logic incorrectly rejects empty color lists (`[[]]`), even though these are passed throughout the codebase to indicate "use default colors."

## Root Cause
In `graph.py` line ~49, the validation logic fails when `cell_bg_colors=[[]]`:
```python
if temp_length != 0:
    raise NotImplementedError
if temp_length != temp_check_length:  # 0 != actual_length
    raise Exception("Must supply one cell_bg_color for every entry")
```

When `temp_length` is 0 (empty list), it still tries to validate against `temp_check_length`, causing the exception.

## Solution
Modified the validation to skip empty color lists:
```python
if temp_length == 0:  # Skip validation if no colors specified
    continue
if temp_length != temp_check_length:
    raise Exception("Must supply one cell_bg_color for every entry")
```

## Testing
Tested locally with the basic example from the README:
```python
from sapai import Team, Battle
from sapai.graph import graph_battle

t0 = Team(["rhino"])
t1 = Team(["pig", "pig", "pig", "hippo"])
b = Battle(t0, t1)
b.battle()
graph_battle(b, file_name="battle_output")
```

Successfully generates battle graph without errors.

## Screenshots
Example colab notebook:
![Battle graph output](https://github.com/user-attachments/assets/3498a5ef-05c3-4516-8fd6-ccd09d2f625e)

Fix Implemented:
<img width="801" height="497" alt="image" src="https://github.com/user-attachments/assets/08996088-ada7-4012-b9bd-cd9cba36415e" />
